### PR TITLE
Fixed: Solver failure Paths were saved in cache as been valid executions

### DIFF
--- a/client/src/main/java/org/evosuite/symbolic/DSEAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSEAlgorithm.java
@@ -85,7 +85,6 @@ public class DSEAlgorithm extends GeneticAlgorithm<TestSuiteChromosome> {
 
     HashSet<Set<Constraint<?>>> pathConditions = new HashSet<Set<Constraint<?>>>();
 
-    // TODO: Try out different ways to stop checking new paths
     for (int currentTestIndex = 0; currentTestIndex < generatedTests
         .size(); currentTestIndex++) {
 

--- a/client/src/main/java/org/evosuite/symbolic/DSEAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSEAlgorithm.java
@@ -85,6 +85,7 @@ public class DSEAlgorithm extends GeneticAlgorithm<TestSuiteChromosome> {
 
     HashSet<Set<Constraint<?>>> pathConditions = new HashSet<Set<Constraint<?>>>();
 
+    // TODO: Try out different ways to stop checking new paths
     for (int currentTestIndex = 0; currentTestIndex < generatedTests
         .size(); currentTestIndex++) {
 
@@ -131,7 +132,6 @@ public class DSEAlgorithm extends GeneticAlgorithm<TestSuiteChromosome> {
         if (pathConditions.contains(constraintSet)) {
           logger.debug("skipping solving of current query because of existing path condition");
           continue;
-
         }
 
         if (isSubSetOf(constraintSet, pathConditions)) {
@@ -154,40 +154,45 @@ public class DSEAlgorithm extends GeneticAlgorithm<TestSuiteChromosome> {
 
         SolverResult result = DSETestGenerator.solve(query);
 
-        queryCache.put(constraintSet, result);
-        logger.debug("Number of stored entries in query cache : " + queryCache.keySet().size());
-
         if (result == null) {
           logger.debug("Solver outcome is null (probably failure/unknown");
-        } else if (result.isSAT()) {
-          logger.debug("query is SAT (solution found)");
-          Map<String, Object> solution = result.getModel();
-          logger.debug("solver found solution " + solution.toString());
-
-          TestCase newTest = DSETestGenerator.updateTest(currentTestCase, solution);
-          logger.debug("Created new test case from SAT solution:" + newTest.toCode());
-          generatedTests.add(newTest);
-
-          double fitnessBeforeAddingNewTest = this.getBestIndividual().getFitness();
-          logger.debug("Fitness before adding new test" + fitnessBeforeAddingNewTest);
-
-          getBestIndividual().addTest(newTest);
-
-          calculateFitness(getBestIndividual());
-
-          double fitnessAfterAddingNewTest = this.getBestIndividual().getFitness();
-          logger.debug("Fitness after adding new test " + fitnessAfterAddingNewTest);
-
-          this.notifyIteration();
-
-          if (fitnessAfterAddingNewTest == 0) {
-            logger.debug("No more DSE test generation since fitness is 0");
-            return;
-          }
-
         } else {
-          assert (result.isUNSAT());
-          logger.debug("query is UNSAT (no solution found)");
+
+          // Saving the result when is not null just to be sure not to save spurious
+          // solver failures / unknowns as already satisfiable in the cache.
+          queryCache.put(constraintSet, result);
+          logger.debug("Number of stored entries in query cache : " + queryCache.keySet().size());
+
+          if (result.isSAT()) {
+            logger.debug("query is SAT (solution found)");
+            Map<String, Object> solution = result.getModel();
+            logger.debug("solver found solution " + solution.toString());
+
+            TestCase newTest = DSETestGenerator.updateTest(currentTestCase, solution);
+            logger.debug("Created new test case from SAT solution:" + newTest.toCode());
+            generatedTests.add(newTest);
+
+            double fitnessBeforeAddingNewTest = this.getBestIndividual().getFitness();
+            logger.debug("Fitness before adding new test" + fitnessBeforeAddingNewTest);
+
+            getBestIndividual().addTest(newTest);
+
+            calculateFitness(getBestIndividual());
+
+            double fitnessAfterAddingNewTest = this.getBestIndividual().getFitness();
+            logger.debug("Fitness after adding new test " + fitnessAfterAddingNewTest);
+
+            this.notifyIteration();
+
+            if (fitnessAfterAddingNewTest == 0) {
+              logger.debug("No more DSE test generation since fitness is 0");
+              return;
+            }
+
+          } else {
+            assert (result.isUNSAT());
+            logger.debug("query is UNSAT (no solution found)");
+          }
         }
       }
     }


### PR DESCRIPTION
# Description
When running the SMT solver, if for any reason it fails and returns **null**, it's saved in the cache as a successfully executed case and then no longer being considered.

// something else? test cases? examples where it breaks?

# Changes
Only successful runs are saved to the cache.