### PR TITLE
Added a simple path divergence check

### DIFF
--- a/client/src/main/java/org/evosuite/TestGenerationContext.java
+++ b/client/src/main/java/org/evosuite/TestGenerationContext.java
@@ -57,7 +57,7 @@ import org.evosuite.setup.ConcreteClassAnalyzer;
 import org.evosuite.setup.DependencyAnalysis;
 import org.evosuite.setup.TestCluster;
 import org.evosuite.setup.TestClusterGenerator;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.testcarver.extraction.CarvingManager;
 import org.evosuite.testcase.execution.ExecutionTracer;
 import org.evosuite.testcase.execution.TestCaseExecutor;
@@ -247,7 +247,7 @@ public class TestGenerationContext {
 
 		Injector.reset();
 
-		DSEStats.clear();
+		DSEStatistics.clear();
 
 		// keep the list of initialized classes (clear them when needed in
 		// the system test cases)

--- a/client/src/main/java/org/evosuite/TestSuiteGenerator.java
+++ b/client/src/main/java/org/evosuite/TestSuiteGenerator.java
@@ -50,7 +50,7 @@ import org.evosuite.setup.TestCluster;
 import org.evosuite.statistics.RuntimeVariable;
 import org.evosuite.statistics.StatisticsSender;
 import org.evosuite.strategy.*;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.testcase.ConstantInliner;
 import org.evosuite.testcase.DefaultTestCase;
 import org.evosuite.testcase.TestCase;
@@ -504,13 +504,13 @@ public class TestSuiteGenerator {
 		if (ArrayUtil.contains(Properties.CRITERION, Criterion.DEFUSE) && Properties.ANALYSIS_CRITERIA.isEmpty())
 			DefUseCoverageSuiteFitness.printCoverage();
 
-		DSEStats.getInstance().trackConstraintTypes();
+		DSEStatistics.getInstance().trackConstraintTypes();
 
-		DSEStats.getInstance().trackSolverStatistics();
+		DSEStatistics.getInstance().trackSolverStatistics();
 
 		if (Properties.DSE_PROBABILITY > 0.0 && Properties.LOCAL_SEARCH_RATE > 0
 				&& Properties.LOCAL_SEARCH_PROBABILITY > 0.0) {
-			DSEStats.getInstance().logStatistics();
+			DSEStatistics.getInstance().logStatistics();
 		}
 
 		if (Properties.FILTER_SANDBOX_TESTS) {

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/GeneticAlgorithm.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/GeneticAlgorithm.java
@@ -53,7 +53,7 @@ import org.evosuite.ga.populationlimit.IndividualPopulationLimit;
 import org.evosuite.ga.populationlimit.PopulationLimit;
 import org.evosuite.ga.stoppingconditions.MaxGenerationStoppingCondition;
 import org.evosuite.ga.stoppingconditions.StoppingCondition;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.testcase.execution.ExecutionTracer;
 import org.evosuite.testsuite.TestSuiteChromosome;
 import org.evosuite.utils.ArrayUtil;
@@ -238,11 +238,11 @@ public abstract class GeneticAlgorithm<T extends Chromosome> implements SearchAl
 		}
 		
 		if (improvement) {
-			DSEStats.getInstance().reportNewIncrease();
+			DSEStatistics.getInstance().reportNewIncrease();
 			updateProbability(true);
 			logger.debug("Increasing probability of applying LS to " + localSearchProbability);
 		} else {
-			DSEStats.getInstance().reportNewDecrease();
+			DSEStatistics.getInstance().reportNewDecrease();
 			updateProbability(false);
 			logger.debug("Decreasing probability of applying LS to " + localSearchProbability);
 		}

--- a/client/src/main/java/org/evosuite/strategy/TestGenerationStrategy.java
+++ b/client/src/main/java/org/evosuite/strategy/TestGenerationStrategy.java
@@ -48,7 +48,7 @@ import org.evosuite.utils.LoggingUtils;
 
 /**
  * This is the abstract superclass of all techniques to generate a set of tests
- * for a target class, which does not neccessarily require the use of a GA.
+ * for a target class, which does not necessarily require the use of a GA.
  * 
  * Postprocessing is not done as part of the test generation strategy.
  * 
@@ -116,7 +116,7 @@ public abstract class TestGenerationStrategy {
 
 		return ffs;
 	}
-	
+
 	/**
 	 * Convert criterion names to factories for test case fitness functions
 	 * @return
@@ -129,11 +129,11 @@ public abstract class TestGenerationStrategy {
 
 		return goalsFactory;
 	}
-	
+
 	/**
 	 * Check if the budget has been used up. The GA will do this check
 	 * on its own, but other strategies (e.g. random) may depend on this function.
-	 * 
+	 *
 	 * @param chromosome
 	 * @param stoppingCondition
 	 * @return

--- a/client/src/main/java/org/evosuite/symbolic/BranchCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/BranchCondition.java
@@ -20,6 +20,7 @@
 package org.evosuite.symbolic;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.evosuite.classpath.ResourceList;
 import org.evosuite.symbolic.expr.Constraint;
@@ -56,14 +57,13 @@ public abstract class BranchCondition {
 	 * belonging to the class in the SUT, the target constraint and all the
 	 * suporting constraint for that particular branch (zero checks, etc)
 	 * 
+	 * @param className             
+	 * @param methodName
+	 * @param instructionIndex
 	 * @param constraint
 	 *            TODO
 	 * @param supportingConstraints
 	 *            a {@link java.util.Set} object.
-	 * @param reachingConstraints
-	 *            a {@link java.util.Set} object.
-	 * @param ins
-	 *            a {@link gov.nasa.jpf.jvm.bytecode.Instruction} object.
 	 */
 	public BranchCondition(String className, String methodName, int instructionIndex, Constraint<?> constraint,
 			List<Constraint<?>> supportingConstraints) {
@@ -123,5 +123,22 @@ public abstract class BranchCondition {
 
 	public String getMethodName() {
 		return methodName;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		BranchCondition that = (BranchCondition) o;
+		return instructionIndex == that.instructionIndex &&
+				className.equals(that.className) &&
+				methodName.equals(that.methodName) &&
+				constraint.equals(that.constraint) &&
+				supportingConstraints.equals(that.supportingConstraints);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(className, methodName, instructionIndex, constraint, supportingConstraints);
 	}
 }

--- a/client/src/main/java/org/evosuite/symbolic/DSE/ConcolicEngine.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/ConcolicEngine.java
@@ -155,7 +155,7 @@ public class ConcolicEngine extends SymbolicEngine {
 		result = TestCaseExecutor.getInstance().execute(defaultTestCase, Properties.CONCOLIC_TIMEOUT);
 
 		long estimatedConcolicExecutionTime = System.currentTimeMillis() - startConcolicExecutionTime;
-		DSEStats.getInstance().reportNewConcolicExecutionTime(estimatedConcolicExecutionTime);
+		DSEStatistics.getInstance().reportNewConcolicExecutionTime(estimatedConcolicExecutionTime);
 
 		MaxStatementsStoppingCondition.statementsExecuted(result.getExecutedStatements());
 		return result;

--- a/client/src/main/java/org/evosuite/symbolic/DSE/DSEStatistics.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/DSEStatistics.java
@@ -42,15 +42,15 @@ import org.slf4j.LoggerFactory;
  * @author galeotti
  * 
  */
-public class DSEStats {
+public class DSEStatistics {
 
-	static Logger logger = LoggerFactory.getLogger(DSEStats.class);
+	static Logger logger = LoggerFactory.getLogger(DSEStatistics.class);
 
-	private static DSEStats instance = null;
+	private static DSEStatistics instance = null;
 
-	public static DSEStats getInstance() {
+	public static DSEStatistics getInstance() {
 		if (instance==null) {
-			instance=new DSEStats();
+			instance=new DSEStatistics();
 		}
 		return instance;
 	}
@@ -66,26 +66,36 @@ public class DSEStats {
 	/**
 	 * This class cannot be built directly 
 	 */
-	private DSEStats() {
+	private DSEStatistics() {
 		
 	}
 
+	// Solver metrics
 	private long nrOfUNSATs = 0;
 	private long nrOfSATs = 0;
 	private long nrOfTimeouts = 0;
-	private long nrOfSolutionWithNoImprovement = 0;
-	private long nrOfNewTestFound = 0;
 	private long totalSolvingTimeMillis = 0;
 	private long totalConcolicExecutionTimeMillis = 0;
 	private int constraintTooLongCounter = 0;
+
+	// New solutions found metrics
+	private long nrOfSolutionWithNoImprovement = 0;
+	private long nrOfNewTestFound = 0;
+
+    // Path condition metrics
+	private int path_condition_count = 0;
+	private int pathsExploredCounter = 0;
+	private int pathDivergencesCounter = 0;
 	private int max_path_condition_length;
 	private int min_path_condition_length;
 	private double avg_path_condition_length;
+
+	// Constraint metrics
+	private int constraint_count = 0;
 	private int max_constraint_size = 0;
 	private int min_constraint_size = 0;
 	private double avg_constraint_size = 0;
-	private int constraint_count = 0;
-	private int path_condition_count = 0;
+
 	private final List<Boolean> changes = new LinkedList<Boolean>();
 	private final ConstraintTypeCounter constraintTypeCounter = new ConstraintTypeCounter();
 
@@ -152,6 +162,21 @@ public class DSEStats {
 		return nrOfNewTestFound;
 	}
 
+	/**
+	 * Invoke this method when a new test found by DSE turned out to diverged.
+	 */
+	public void reportNewPathDivergence() {
+		pathDivergencesCounter++;
+	}
+
+	/**
+	 * Invoke this method when a new path condition is found.
+	 */
+	public void reportNewPathExplored() {
+		pathsExploredCounter++;
+	}
+
+
 	public void logStatistics() {
 
 		logger.info("* DSE Statistics");
@@ -163,6 +188,9 @@ public class DSEStats {
 
 		logger.info("");
 		logPathConditionLengthStatistics();
+
+		logger.info("");
+		logPathsExploredStatistics();
 
 		logger.info("");
 		logTimeStatistics();
@@ -179,6 +207,12 @@ public class DSEStats {
 		logConstraintTypeStatistics();
 		logger.info("");
 
+	}
+
+	private void logPathsExploredStatistics() {
+		logger.info("* DSE) Paths exploration:");
+		logger.info(String.format("* DSE)   paths explored: %s", pathsExploredCounter));
+		logger.info(String.format("* DSE)   diverged paths: %s", pathDivergencesCounter));
 	}
 
 	private void logAdaptationStatistics() {
@@ -333,6 +367,10 @@ public class DSEStats {
 
 	private int getConstraintTooLongCounter() {
 		return constraintTooLongCounter;
+	}
+
+	private int getPathDivergencesCounter() {
+		return pathDivergencesCounter;
 	}
 
 	public void reportNewConstraints(Collection<Constraint<?>> constraints) {

--- a/client/src/main/java/org/evosuite/symbolic/DSE/DSEStrategy.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/DSEStrategy.java
@@ -62,7 +62,8 @@ public class DSEStrategy extends TestGenerationStrategy {
 		// What's the search target
 		List<TestSuiteFitnessFunction> fitnessFunctions = getFitnessFunctions();
 
-		List<TestFitnessFunction> goals = getGoals(true);
+		//TODO: move this to a dependency injection schema
+		List<TestFitnessFunction> goals = getFitnessFunctionsGoals(true);
 		if (!canGenerateTestsForSUT()) {
 			LoggingUtils.getEvoLogger()
 					.info("* Found no testable methods in the target class " + Properties.TARGET_CLASS);
@@ -88,12 +89,13 @@ public class DSEStrategy extends TestGenerationStrategy {
             DSEAlgorithm algorithm = dseFactory.getDSEAlgorithm(dseAlgorithmType);
 
 			StoppingCondition stoppingCondition = getStoppingCondition();
-// TODO: implement fitness functions
-			//						algorithm.addFitnessFunctions((List)fitnessFunctions);
+
+			algorithm.addFitnessFunctions((List)fitnessFunctions);
 			if (Properties.STOP_ZERO) {
 
 			}
-//			algorithm.setStoppingCondition(stoppingCondition);
+
+			//algorithm.setStoppingCondition(stoppingCondition);
 			testSuite = algorithm.generateSolution();;
 
 		} else {
@@ -106,7 +108,7 @@ public class DSEStrategy extends TestGenerationStrategy {
 
 		long endTime = System.currentTimeMillis() / 1000;
 
-		goals = getGoals(false); // recalculated now after the search, eg to
+		goals = getFitnessFunctionsGoals(false); // recalculated now after the search, eg to
 									// handle exception fitness
 		ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Total_Goals, goals.size());
 
@@ -131,7 +133,13 @@ public class DSEStrategy extends TestGenerationStrategy {
 
 	}
 
-	private List<TestFitnessFunction> getGoals(boolean verbose) {
+	 /**
+     * Returns current Fitness functions based on which Properties are currently set.
+     *
+     * @param verbose
+     * @return
+     */
+    private static List<TestFitnessFunction> getFitnessFunctionsGoals(boolean verbose) {
 		List<TestFitnessFactory<? extends TestFitnessFunction>> goalFactories = getFitnessFactories();
 		List<TestFitnessFunction> goals = new ArrayList<>();
 

--- a/client/src/main/java/org/evosuite/symbolic/DSE/DSETestGenerator.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/DSETestGenerator.java
@@ -31,7 +31,6 @@ import org.evosuite.ga.localsearch.LocalSearchObjective;
 import org.evosuite.symbolic.BranchCondition;
 import org.evosuite.symbolic.PathCondition;
 import org.evosuite.symbolic.expr.Constraint;
-import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.Variable;
 import org.evosuite.symbolic.solver.*;
 import org.evosuite.testcase.DefaultTestCase;
@@ -163,7 +162,7 @@ public class DSETestGenerator {
 				logger.info("  " + c);
 			}
 
-			DSEStats.getInstance().reportNewConstraints(query);
+			DSEStatistics.getInstance().reportNewConstraints(query);
 
 			long startSolvingTime = System.currentTimeMillis();
 
@@ -171,17 +170,17 @@ public class DSETestGenerator {
 			SolverResult solverResult = SolverUtils.solveQuery(query);
 
 			long estimatedSolvingTime = System.currentTimeMillis() - startSolvingTime;
-			DSEStats.getInstance().reportNewSolvingTime(estimatedSolvingTime);
+			DSEStatistics.getInstance().reportNewSolvingTime(estimatedSolvingTime);
 
 			if (solverResult == null) {
 				logger.info("Found no result");
 
 			} else if (solverResult.isUNSAT()) {
 				logger.info("Found UNSAT result");
-				DSEStats.getInstance().reportNewUNSAT();
+				DSEStatistics.getInstance().reportNewUNSAT();
 			} else {
 				logger.info("Found SAT result");
-				DSEStats.getInstance().reportNewSAT();
+				DSEStatistics.getInstance().reportNewSAT();
 				Map<String, Object> model = solverResult.getModel();
 				TestCase oldTest = test.getTestCase();
 				ExecutionResult oldResult = test.getLastExecutionResult().clone();
@@ -192,12 +191,12 @@ public class DSETestGenerator {
 				test.clearCachedResults();
 
 				if (objective.hasImproved(test)) {
-					DSEStats.getInstance().reportNewTestUseful();
+					DSEStatistics.getInstance().reportNewTestUseful();
 					logger.info("Solution improves fitness, finishing DSE");
 					/* new test was created */
 					return test;
 				} else {
-					DSEStats.getInstance().reportNewTestUnuseful();
+					DSEStatistics.getInstance().reportNewTestUnuseful();
 					test.setTestCase(oldTest);
 					// FIXXME: How can this be null?
 					if (oldResult != null)

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithm.java
@@ -20,6 +20,7 @@
 package org.evosuite.symbolic.DSE.algorithm;
 
 import org.evosuite.symbolic.DSE.ConcolicEngine;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.DSE.DSETestGenerator;
 import org.evosuite.symbolic.DSE.algorithm.strategies.TestCaseBuildingStrategy;
 import org.evosuite.symbolic.DSE.algorithm.strategies.TestCaseSelectionStrategy;
@@ -92,6 +93,7 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
 
     public DSEAlgorithm() {
         this(
+            DSEStatistics.getInstance(), //TODO: move this to a dependency injection schema
             new ConcolicEngine(),
             SolverFactory.getInstance().buildNewSolver(),
 
@@ -105,6 +107,7 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
     }
 
     public DSEAlgorithm(
+            DSEStatistics dseStatistics,
             ConcolicEngine engine,
             Solver solver,
             PathPruningStrategy pathPruningStrategy,
@@ -113,6 +116,8 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
             TestCaseBuildingStrategy testCaseBuildingStrategy,
             TestCaseSelectionStrategy testCaseSelectionStrategy
     ) {
+        super(dseStatistics);
+
         this.engine = engine;
         this.solver = solver;
 
@@ -162,6 +167,7 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
 
     /**
      * Analyzes the results of an smtQuery and appends to the tests cases if needed
+     *
      *  @param query
      * @param smtQueryResult
      * @param generatedTests
@@ -214,6 +220,9 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
      */
      public TestSuiteChromosome generateSolution() {
          // TODO: completar
+
+         // Run this before finish
+         statisticsLogger.logStatistics();
          return null;
      }
 

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithmFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithmFactory.java
@@ -19,6 +19,8 @@
  */
 package org.evosuite.symbolic.DSE.algorithm;
 
+import org.evosuite.symbolic.DSE.DSEStatistics;
+
 /**
  * Factory of DSE Algorithms
  *
@@ -26,6 +28,11 @@ package org.evosuite.symbolic.DSE.algorithm;
  */
 public class DSEAlgorithmFactory {
     private final static String DSE_ALGORITHM_TYPE_NOT_PROVIDED = "A DSE algorithm type must be provided";
+
+    /**
+    * Statistics object for when creating a customized algorithm
+    */
+    private final DSEStatistics dseStatistics = DSEStatistics.getInstance();
 
     public DSEAlgorithm getDSEAlgorithm(DSEAlgorithms dseAlgorithmType) {
         if (dseAlgorithmType == null) {

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
@@ -23,6 +23,10 @@ import org.evosuite.ga.Chromosome;
 import org.evosuite.ga.FitnessFunction;
 import org.evosuite.ga.stoppingconditions.StoppingCondition;
 import org.evosuite.symbolic.DSE.algorithm.listener.SymbolicExecutionSearchListener;
+import org.evosuite.symbolic.PathCondition;
+import org.evosuite.symbolic.PathConditionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,6 +40,11 @@ import java.util.Set;
  */
 public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 
+	/** Logger Messages */
+	private static final String PATH_DIVERGENCE_FOUND_WARNING_MESSAGE = "Warning | Path condition diverged";
+
+	private static final Logger logger = LoggerFactory.getLogger(DSEBaseAlgorithm.class);
+
 	/** Listeners */
 	protected transient Set<SymbolicExecutionSearchListener> listeners = new HashSet<SymbolicExecutionSearchListener>();
 
@@ -44,6 +53,10 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 
 	/** List of conditions on which to end the search */
 	protected transient Set<StoppingCondition> stoppingConditions = new HashSet<StoppingCondition>();
+
+	/** Amount of divergences **/
+	protected Integer totalAmountOfPaths = 0;
+	protected Integer amountOfPathDivergences = 0;
 
 	/**
 	 * Add new fitness function (i.e., for new mutation)
@@ -175,4 +188,20 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 
 		return (double) currentbudget / (double) totalbudget;
 	}
+
+    /**
+     * Checks whether the current executed path condition diverged from the original one.
+     * TODO: Maybe we can give some info about the PathCondition that diverged later on
+	 *
+     * @param currentPathCondition
+     */
+    protected void checkPathConditionDivergence(PathCondition currentPathCondition, PathCondition expectedPathCondition) {
+    	totalAmountOfPaths++;
+
+        if (PathConditionUtils.hasPathConditionDiverged(expectedPathCondition, currentPathCondition)) {
+            logger.debug(PATH_DIVERGENCE_FOUND_WARNING_MESSAGE);
+        	amountOfPathDivergences++;
+        }
+    }
+
 }

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
@@ -22,6 +22,7 @@ package org.evosuite.symbolic.DSE.algorithm;
 import org.evosuite.ga.Chromosome;
 import org.evosuite.ga.FitnessFunction;
 import org.evosuite.ga.stoppingconditions.StoppingCondition;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.DSE.algorithm.listener.SymbolicExecutionSearchListener;
 import org.evosuite.symbolic.PathCondition;
 import org.evosuite.symbolic.PathConditionUtils;
@@ -45,6 +46,8 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 
 	private static final Logger logger = LoggerFactory.getLogger(DSEBaseAlgorithm.class);
 
+	protected final DSEStatistics statisticsLogger;
+
 	/** Listeners */
 	protected transient Set<SymbolicExecutionSearchListener> listeners = new HashSet<SymbolicExecutionSearchListener>();
 
@@ -57,6 +60,10 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 	/** Amount of divergences **/
 	protected Integer totalAmountOfPaths = 0;
 	protected Integer amountOfPathDivergences = 0;
+
+	public DSEBaseAlgorithm(DSEStatistics dseStatistics) {
+		this.statisticsLogger = dseStatistics;
+	}
 
 	/**
 	 * Add new fitness function (i.e., for new mutation)
@@ -196,11 +203,12 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
      * @param currentPathCondition
      */
     protected void checkPathConditionDivergence(PathCondition currentPathCondition, PathCondition expectedPathCondition) {
-    	totalAmountOfPaths++;
+    	statisticsLogger.reportNewPathExplored();
 
         if (PathConditionUtils.hasPathConditionDiverged(expectedPathCondition, currentPathCondition)) {
             logger.debug(PATH_DIVERGENCE_FOUND_WARNING_MESSAGE);
-        	amountOfPathDivergences++;
+        	statisticsLogger.reportNewPathDivergence();
+
         }
     }
 

--- a/client/src/main/java/org/evosuite/symbolic/PathConditionUtils.java
+++ b/client/src/main/java/org/evosuite/symbolic/PathConditionUtils.java
@@ -40,7 +40,7 @@ public class PathConditionUtils {
 	 *
 	 *  TODO: In the future we can support explaining which condition diverged.
 	 *  		And Maybe talk about what happened, it's doesn't seem to be trivial to
-	 *  	    check where the divergence generated but there may be an aprox technique that
+	 *  	    check where the divergence generated but there may be an aprox. technique that
 	 *  	    may give us some information about it.
 	 *
 	 * @param expectedPrefixPathCondition

--- a/client/src/main/java/org/evosuite/symbolic/PathConditionUtils.java
+++ b/client/src/main/java/org/evosuite/symbolic/PathConditionUtils.java
@@ -43,25 +43,39 @@ public class PathConditionUtils {
 	 *  	    check where the divergence generated but there may be an aprox technique that
 	 *  	    may give us some information about it.
 	 *
-	 * @param original
+	 * @param expectedPrefixPathCondition
 	 * @param newPathCondition
 	 * @return
 	 */
-	public static boolean hasPathConditionDiverged(PathCondition original, PathCondition newPathCondition) {
-		List<BranchCondition> originalBranchConditions = original.getBranchConditions();
+	public static boolean hasPathConditionDiverged(PathCondition expectedPrefixPathCondition, PathCondition newPathCondition) {
+		List<BranchCondition> expectedPrefixBranchConditions = expectedPrefixPathCondition.getBranchConditions();
 		List<BranchCondition> newBranchConditions = newPathCondition.getBranchConditions();
 
-		for (int currentBranchConditionIndex = 0; currentBranchConditionIndex < originalBranchConditions.size(); ++currentBranchConditionIndex) {
-			BranchCondition originalBranchCondition = originalBranchConditions.get(currentBranchConditionIndex);
+		for (int currentBranchConditionIndex = 0; currentBranchConditionIndex < expectedPrefixBranchConditions.size(); ++currentBranchConditionIndex) {
+			BranchCondition expectedPrefixBranchCondition = expectedPrefixBranchConditions.get(currentBranchConditionIndex);
 			BranchCondition newBranchCondition = newBranchConditions.get(currentBranchConditionIndex);
 
-			// if the original path is not a prefix of the current one, there's a divergence
-			if (!originalBranchCondition.equals(newBranchCondition)) {
+			// if the expectedPrefix path is not a prefix of the current one, there's a divergence
+			if (!expectedPrefixBranchCondition.equals(newBranchCondition)) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Calculates the path divergece vs total paths ratio.
+	 *
+	 * @param pathDivergeAmount
+	 * @param totalPathsAmount
+	 * @return
+	 */
+	public static double calculatePathDivergenceRatio(int pathDivergeAmount, int totalPathsAmount) {
+		double divergenceAmount = pathDivergeAmount;
+		double pathsAmount = totalPathsAmount;
+
+		return pathDivergeAmount / totalPathsAmount;
 	}
 
 }

--- a/client/src/main/java/org/evosuite/symbolic/PathConditionUtils.java
+++ b/client/src/main/java/org/evosuite/symbolic/PathConditionUtils.java
@@ -3,20 +3,22 @@ package org.evosuite.symbolic;
 import org.evosuite.symbolic.expr.Constraint;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public class PathConditionUtils {
     /**
 	   * Returns true if the constraints in the query are a subset of any of the constraints in the set
-	   * of queries
+	   * of queries.
 	   *
 	   * @param query
 	   * @param queries
 	   * @return
 	   */
-    public static boolean isConstraintSetSubSetOf(Set<Constraint<?>> query,
-                                                  Collection<Set<Constraint<?>>> queries) {
-
+    public static boolean isConstraintSetSubSetOf(
+    	Set<Constraint<?>> query,
+		Collection<Set<Constraint<?>>> queries)
+	{
         for (Set<Constraint<?>> pathCondition : queries) {
 		  if (pathCondition.containsAll(query)) {
 			return true;
@@ -25,5 +27,41 @@ public class PathConditionUtils {
 
         return false;
     }
+
+    /**
+	 * Checks whether the current path condition explored has diverged from it's supposed path.
+	 * We simply check that the original path condition from which the new test was created
+	 * is a prefix of the actual path being explored.
+	 *
+	 * TODO: see how to cite this paper properly.
+	 * Idea taken from: An empirical investigation into path divergences for
+	 * 		concolic execution using CREST,
+	 *  	Ting Chen, Xiaodong Lin, Jin Huang, Abel Bacchus and Xiaosong Zhang
+	 *
+	 *  TODO: In the future we can support explaining which condition diverged.
+	 *  		And Maybe talk about what happened, it's doesn't seem to be trivial to
+	 *  	    check where the divergence generated but there may be an aprox technique that
+	 *  	    may give us some information about it.
+	 *
+	 * @param original
+	 * @param newPathCondition
+	 * @return
+	 */
+	public static boolean hasPathConditionDiverged(PathCondition original, PathCondition newPathCondition) {
+		List<BranchCondition> originalBranchConditions = original.getBranchConditions();
+		List<BranchCondition> newBranchConditions = newPathCondition.getBranchConditions();
+
+		for (int currentBranchConditionIndex = 0; currentBranchConditionIndex < originalBranchConditions.size(); ++currentBranchConditionIndex) {
+			BranchCondition originalBranchCondition = originalBranchConditions.get(currentBranchConditionIndex);
+			BranchCondition newBranchCondition = newBranchConditions.get(currentBranchConditionIndex);
+
+			// if the original path is not a prefix of the current one, there's a divergence
+			if (!originalBranchCondition.equals(newBranchCondition)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 }

--- a/client/src/main/java/org/evosuite/symbolic/expr/IntegerConstraint.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/IntegerConstraint.java
@@ -21,7 +21,7 @@ package org.evosuite.symbolic.expr;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ public final class IntegerConstraint extends Constraint<Long> {
 		this.cmp = cmp;
 		this.right = right;
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/RealConstraint.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/RealConstraint.java
@@ -21,7 +21,7 @@ package org.evosuite.symbolic.expr;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ public final class RealConstraint extends Constraint<Double> {
 		this.cmp = cmp;
 		this.right = right;
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/StringConstraint.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/StringConstraint.java
@@ -18,7 +18,7 @@ package org.evosuite.symbolic.expr;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.bv.IntegerConstant;
 import org.evosuite.symbolic.expr.bv.StringComparison;
 import org.slf4j.Logger;
@@ -34,7 +34,7 @@ public final class StringConstraint extends Constraint<String> {
     this.cmp = comp;
     this.right = right;
     if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-      DSEStats.getInstance().reportConstraintTooLong(getSize());
+      DSEStatistics.getInstance().reportConstraintTooLong(getSize());
       throw new ConstraintTooLongException(getSize());
     }
   }

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/IntegerComparison.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/IntegerComparison.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -56,7 +56,7 @@ public final class IntegerComparison extends AbstractExpression<Long> implements
 		this.right = right;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/IntegerUnaryExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/IntegerUnaryExpression.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -62,7 +62,7 @@ public final class IntegerUnaryExpression extends AbstractExpression<Long> imple
 		this.op = op2;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/RealComparison.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/RealComparison.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -57,7 +57,7 @@ public final class RealComparison extends AbstractExpression<Long> implements
 		this.right = right;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/RealToIntegerCast.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/RealToIntegerCast.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Cast;
 import org.evosuite.symbolic.expr.Expression;
@@ -53,7 +53,7 @@ public final class RealToIntegerCast extends AbstractExpression<Long> implements
 		this.expr = _expr;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/RealUnaryToIntegerExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/RealUnaryToIntegerExpression.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -63,7 +63,7 @@ public final class RealUnaryToIntegerExpression extends AbstractExpression<Long>
 		this.op = op2;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/StringBinaryComparison.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/StringBinaryComparison.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -73,7 +73,7 @@ public final class StringBinaryComparison extends AbstractExpression<Long> imple
 		this.right = right;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/StringBinaryToIntegerExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/StringBinaryToIntegerExpression.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.BinaryExpression;
 import org.evosuite.symbolic.expr.Expression;
@@ -82,7 +82,7 @@ public final class StringBinaryToIntegerExpression extends
 		this.right = right2;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/StringMultipleComparison.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/StringMultipleComparison.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -87,7 +87,7 @@ public final class StringMultipleComparison extends AbstractExpression<Long> imp
 		this.other_v = _other;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/StringMultipleToIntegerExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/StringMultipleToIntegerExpression.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -88,7 +88,7 @@ public final class StringMultipleToIntegerExpression extends AbstractExpression<
 		this.other_v = _other;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/StringToIntegerCast.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/StringToIntegerCast.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Cast;
 import org.evosuite.symbolic.expr.Expression;
@@ -62,7 +62,7 @@ public final class StringToIntegerCast extends AbstractExpression<Long> implemen
 		super(_concValue, 1 + _expr.getSize(), _expr.containsSymbolicVariable());
 		this.expr = _expr;
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/bv/StringUnaryToIntegerExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/bv/StringUnaryToIntegerExpression.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -75,7 +75,7 @@ public final class StringUnaryToIntegerExpression extends AbstractExpression<Lon
 		this.op = op2;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/fp/IntegerToRealCast.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/fp/IntegerToRealCast.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Cast;
 import org.evosuite.symbolic.expr.Expression;
@@ -53,7 +53,7 @@ public final class IntegerToRealCast extends AbstractExpression<Double> implemen
 		this.expr = _expr;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/fp/RealUnaryExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/fp/RealUnaryExpression.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -63,7 +63,7 @@ public final class RealUnaryExpression extends AbstractExpression<Double> implem
 		this.op = op2;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/str/IntegerToStringCast.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/str/IntegerToStringCast.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Cast;
 import org.evosuite.symbolic.expr.Expression;
@@ -47,7 +47,7 @@ public final class IntegerToStringCast extends AbstractExpression<String> implem
 		this.expr = expr;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/str/RealToStringCast.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/str/RealToStringCast.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Cast;
 import org.evosuite.symbolic.expr.Expression;
@@ -47,7 +47,7 @@ public final class RealToStringCast extends AbstractExpression<String> implement
 		this.expr = _expr;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 

--- a/client/src/main/java/org/evosuite/symbolic/expr/str/StringBinaryExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/str/StringBinaryExpression.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.BinaryExpression;
 import org.evosuite.symbolic.expr.Expression;
@@ -78,7 +78,7 @@ public final class StringBinaryExpression extends AbstractExpression<String> imp
 		this.right = right2;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/str/StringMultipleExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/str/StringMultipleExpression.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -88,7 +88,7 @@ public final class StringMultipleExpression extends AbstractExpression<String> i
 		this.other_v = _other;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/str/StringUnaryExpression.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/str/StringUnaryExpression.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.Expression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
@@ -75,7 +75,7 @@ public final class StringUnaryExpression extends AbstractExpression<String> impl
 		this.op = op2;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/token/HasMoreTokensExpr.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/token/HasMoreTokensExpr.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
 import org.evosuite.symbolic.expr.Variable;
@@ -56,7 +56,7 @@ public final class HasMoreTokensExpr extends AbstractExpression<Long> implements
 		this.tokenizerExpr = tokenizerExpr;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/expr/token/StringNextTokenExpr.java
+++ b/client/src/main/java/org/evosuite/symbolic/expr/token/StringNextTokenExpr.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.evosuite.Properties;
 import org.evosuite.symbolic.ConstraintTooLongException;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.AbstractExpression;
 import org.evosuite.symbolic.expr.ExpressionVisitor;
 import org.evosuite.symbolic.expr.Variable;
@@ -59,7 +59,7 @@ public final class StringNextTokenExpr extends AbstractExpression<String> implem
 		this.tokenizerExpr = tokenizerExpr;
 
 		if (getSize() > Properties.DSE_CONSTRAINT_LENGTH) {
-			DSEStats.getInstance().reportConstraintTooLong(getSize());
+			DSEStatistics.getInstance().reportConstraintTooLong(getSize());
 			throw new ConstraintTooLongException(getSize());
 		}
 	}

--- a/client/src/main/java/org/evosuite/symbolic/solver/SolverUtils.java
+++ b/client/src/main/java/org/evosuite/symbolic/solver/SolverUtils.java
@@ -41,12 +41,11 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Logic for calling the SMT solver
+ * SMT solver related Logic.
  * TODO: in the future it could a good idea to avoid using static objects and move
  * 		 to a dependency injection schema.
  *
  * @author ilebrero
- *
  */
 public abstract class SolverUtils {
 
@@ -70,7 +69,12 @@ public abstract class SolverUtils {
 		return solverResult;
 	}
 
-	// TODO: check that this is ok
+	/**
+	 * Creates boundaries for the SMT query variables.
+	 *
+	 * @param query
+	 * @return
+	 */
      public static Collection<? extends Constraint<?>> createBoundsForQueryVariables(List<Constraint<?>> query) {
         Set<Variable<?>> variables = new HashSet<Variable<?>>();
         for (Constraint<?> constraint : query) {

--- a/client/src/main/java/org/evosuite/testsuite/localsearch/DeprecatedTestSuiteDSE.java
+++ b/client/src/main/java/org/evosuite/testsuite/localsearch/DeprecatedTestSuiteDSE.java
@@ -36,7 +36,7 @@ import org.evosuite.ga.localsearch.LocalSearchBudget;
 import org.evosuite.ga.localsearch.LocalSearchObjective;
 import org.evosuite.symbolic.BranchCondition;
 import org.evosuite.symbolic.DSE.ConcolicEngine;
-import org.evosuite.symbolic.DSE.DSEStats;
+import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.expr.Comparator;
 import org.evosuite.symbolic.expr.Constraint;
 import org.evosuite.symbolic.expr.Expression;
@@ -354,12 +354,12 @@ public class DeprecatedTestSuiteDSE {
 		nrConstraints += nrCurrConstraints;
 
 		logger.info("Applying local search");
-		DSEStats.getInstance().reportNewConstraints(constraints);
+		DSEStatistics.getInstance().reportNewConstraints(constraints);
 
 		long startSolvingTime = System.currentTimeMillis();
 		SolverResult solverResult = SolverUtils.solveQuery(constraints);
 		long estimatedSolvingTime = System.currentTimeMillis() - startSolvingTime;
-		DSEStats.getInstance().reportNewSolvingTime(estimatedSolvingTime);
+		DSEStatistics.getInstance().reportNewSolvingTime(estimatedSolvingTime);
 
 		if (solverResult == null) {
 			logger.info("Found no solution");
@@ -369,13 +369,13 @@ public class DeprecatedTestSuiteDSE {
 		} else if (solverResult.isUNSAT()) {
 
 			logger.info("Found UNSAT solution");
-			DSEStats.getInstance().reportNewUNSAT();
+			DSEStatistics.getInstance().reportNewUNSAT();
 			return null;
 
 		} else {
 
 			Map<String, Object> model = solverResult.getModel();
-			DSEStats.getInstance().reportNewSAT();
+			DSEStatistics.getInstance().reportNewSAT();
 
 			TestCase newTest = test.clone();
 
@@ -652,7 +652,7 @@ public class DeprecatedTestSuiteDSE {
 
 					if (getFitness(expandedTests) < originalFitness) {
 						logger.info("New test improves fitness to {}", getFitness(expandedTests));
-						DSEStats.getInstance().reportNewTestUseful();
+						DSEStatistics.getInstance().reportNewTestUseful();
 						wasSuccess = true;
 
 						// no need to clone so we can keep executionresult
@@ -664,7 +664,7 @@ public class DeprecatedTestSuiteDSE {
 						// ZeroFitness is a stopping condition
 					} else {
 						logger.info("New test does not improve fitness");
-						DSEStats.getInstance().reportNewTestUnuseful();
+						DSEStatistics.getInstance().reportNewTestUnuseful();
 						expandedTests.deleteTest(newTest);
 					}
 				}

--- a/master/src/test/java/com/examples/with/different/packagename/dse/PathDivergeUsingHashExample.java
+++ b/master/src/test/java/com/examples/with/different/packagename/dse/PathDivergeUsingHashExample.java
@@ -1,0 +1,22 @@
+package com.examples.with.different.packagename.dse;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/**
+ * Classic path divergence problem example.
+ */
+public class PathDivergeUsingHashExample {
+    public PathDivergeUsingHashExample() {}
+
+    public static int test (int x, int y) {
+		if (x != new HashCodeBuilder().append(y).build()) {
+			if (y == 10) {
+				return -1;
+			} else {
+				return 1;
+			}
+		}
+
+		return 0;
+	}
+}

--- a/master/src/test/java/org/evosuite/dse/DSEAlgorithmSystemTest.java
+++ b/master/src/test/java/org/evosuite/dse/DSEAlgorithmSystemTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import com.examples.with.different.packagename.dse.PathDivergeUsingHashExample;
 import org.evosuite.EvoSuite;
 import org.evosuite.Properties;
 import org.evosuite.Properties.Criterion;
@@ -91,7 +92,6 @@ public class DSEAlgorithmSystemTest extends SystemTestBase {
 
 	@Test
 	public void testMax() {
-
 		EvoSuite evosuite = new EvoSuite();
 		String targetClass = Max.class.getCanonicalName();
 		Properties.TARGET_CLASS = targetClass;
@@ -518,7 +518,28 @@ public class DSEAlgorithmSystemTest extends SystemTestBase {
 		assertFalse(best.getTests().isEmpty());
 
 		assertTrue(best.getNumOfCoveredGoals() >= 3);
-
 	}
 
+
+	/**
+	 * Given that the concolic engine makes the un-instrumented functions results concrete, the hashing case gets covered..
+	 *
+	 * See examples on: Patrice Godefroid - Higher-Order Test Generation.
+	 */
+	@Test
+	public void testPathDivergenceWithHashingfunction() {
+		EvoSuite evosuite = new EvoSuite();
+		String targetClass = PathDivergeUsingHashExample.class.getCanonicalName();
+		Properties.TARGET_CLASS = targetClass;
+
+		String[] command = new String[] { "-generateSuite", "-class", targetClass };
+
+		Object result = evosuite.parseCommandLine(command);
+		GeneticAlgorithm<?> ga = getGAFromResult(result);
+		TestSuiteChromosome best = (TestSuiteChromosome) ga.getBestIndividual();
+		System.out.println("EvolvedTestSuite:\n" + best);
+
+		assertFalse(best.getTests().isEmpty());
+		assertTrue(best.getNumOfCoveredGoals() >= 3);
+	}
 }


### PR DESCRIPTION
# Details
It simply checks that the path condition upon which the executed test case was based is a prefix of the resulted execution.  Based on the implementation of [An empirical investigation into path divergences for concolic execution using CREST](https://www.researchgate.net/publication/279519315_An_empirical_investigation_into_path_divergences_for_concolic_execution_using_CREST).

# Changes
- Added the algorithm in PathConditionUtils
- Added Equals and Hashcode to Branchcondition
- Added proof of concept impl to the new dse algorithm
- Added a proof of concept test based on the clasic hash function problem (See paper above)
- Added reporting for path divergences to DSEStatistics