### PR TITLE
Added Stopping Conditions to the DSE algorithm

### DIFF
--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -410,6 +410,10 @@ public class Properties {
 	@Parameter(key = "dse_variable_resets", group = "DSE", description = "Times DSE resets the int and real variables with random values")
 	public static int DSE_VARIABLE_RESETS = 2;
 
+    // By default the target is 100
+	@Parameter(key = "dse_target_coverage", group = "DSE", description = "Percentage (out of 100) of target coverage to cover")
+	public static int DSE_TARGET_COVERAGE = 100;
+
 	public enum DSEType {
 		/** apply DSE per statement */
 		STATEMENT,
@@ -443,6 +447,11 @@ public class Properties {
 	@Parameter(key = "cvc4_path", group = "DSE", description = "Indicates the path to the CVC4 solver")
 	public static String CVC4_PATH = null;
 
+	public enum DSEStoppingCondition {
+		TARGETCOVERAGE,
+        /** Max time in seconds */ MAXTIME,
+        ZEROFITNESS
+	}
 
 	// --------- LS ---------
 
@@ -613,7 +622,6 @@ public class Properties {
         /** Max time in seconds */ MAXTIME,
         MAXGENERATIONS, MAXFITNESSEVALUATIONS, TIMEDELTA
 	}
-
 
 	@Parameter(key = "stopping_condition", group = "Search Algorithm", description = "What condition should be checked to end the search")
 	public static StoppingCondition STOPPING_CONDITION = StoppingCondition.MAXTIME;

--- a/client/src/main/java/org/evosuite/coverage/FitnessFunctionsUtils.java
+++ b/client/src/main/java/org/evosuite/coverage/FitnessFunctionsUtils.java
@@ -54,7 +54,8 @@ public class FitnessFunctionsUtils {
 
     /**
 	 * Convert criterion names to factories for test case fitness functions
-	 * @return
+	 * @param criterion
+     * @return
 	 */
 	public static List<TestFitnessFactory<? extends TestFitnessFunction>> getFitnessFactories(Properties.Criterion[] criterion) {
 	    List<TestFitnessFactory<? extends TestFitnessFunction>> goalsFactory = new ArrayList<TestFitnessFactory<? extends TestFitnessFunction>>();
@@ -63,5 +64,49 @@ public class FitnessFunctionsUtils {
 	    }
 
 		return goalsFactory;
+	}
+
+	/**
+     * Returns current Fitness functions based on which criterion was passed.
+     *
+     * @param criterion
+     * @param verbose
+     * @return
+     */
+    public static List<TestFitnessFunction> getFitnessFunctionsGoals(Properties.Criterion[] criterion, boolean verbose) {
+		List<TestFitnessFactory<? extends TestFitnessFunction>> goalFactories = getFitnessFactories(criterion);
+		List<TestFitnessFunction> goals = new ArrayList<>();
+
+		if (goalFactories.size() == 1) {
+			TestFitnessFactory<? extends TestFitnessFunction> factory = goalFactories.iterator().next();
+			goals.addAll(factory.getCoverageGoals());
+
+			if (verbose) {
+				LoggingUtils.getEvoLogger().info("* Total number of test goals: {}", factory.getCoverageGoals().size());
+				if (Properties.PRINT_GOALS) {
+					for (TestFitnessFunction goal : factory.getCoverageGoals())
+						LoggingUtils.getEvoLogger().info("" + goal.toString());
+				}
+			}
+		} else {
+			if (verbose) {
+				LoggingUtils.getEvoLogger().info("* Total number of test goals: ");
+			}
+
+			for (TestFitnessFactory<? extends TestFitnessFunction> goalFactory : goalFactories) {
+				goals.addAll(goalFactory.getCoverageGoals());
+
+				if (verbose) {
+					LoggingUtils.getEvoLogger()
+							.info("  - " + goalFactory.getClass().getSimpleName().replace("CoverageFactory", "") + " "
+									+ goalFactory.getCoverageGoals().size());
+					if (Properties.PRINT_GOALS) {
+						for (TestFitnessFunction goal : goalFactory.getCoverageGoals())
+							LoggingUtils.getEvoLogger().info("" + goal.toString());
+					}
+				}
+			}
+		}
+		return goals;
 	}
 }

--- a/client/src/main/java/org/evosuite/ga/Chromosome.java
+++ b/client/src/main/java/org/evosuite/ga/Chromosome.java
@@ -38,6 +38,10 @@ public abstract class Chromosome implements Comparable<Chromosome>, Serializable
 
 	private static final long serialVersionUID = -6921897301005213358L;
 
+	/** General Class Related Constants */
+	public static final double MAX_COVERAGE_REACHABLE = 1.0;
+	public static final double MIN_COVERAGE_REACHABLE = 0.0;
+
 	/** Constant <code>logger</code> */
 	private static final Logger logger = LoggerFactory.getLogger(Chromosome.class);
 

--- a/client/src/main/java/org/evosuite/symbolic/DSE/DSEStrategy.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/DSEStrategy.java
@@ -36,6 +36,9 @@ import org.evosuite.strategy.TestGenerationStrategy;
 import org.evosuite.symbolic.DSE.algorithm.DSEAlgorithm;
 import org.evosuite.symbolic.DSE.algorithm.DSEAlgorithmFactory;
 import org.evosuite.symbolic.DSE.algorithm.DSEAlgorithms;
+import org.evosuite.symbolic.DSE.algorithm.listener.implementations.MaxTimeStoppingCondition;
+import org.evosuite.symbolic.DSE.algorithm.listener.implementations.TargetCoverageReachedStoppingCondition;
+import org.evosuite.symbolic.DSE.algorithm.listener.implementations.ZeroFitnessStoppingCondition;
 import org.evosuite.testcase.TestFitnessFunction;
 import org.evosuite.testsuite.TestSuiteChromosome;
 import org.evosuite.testsuite.TestSuiteFitnessFunction;
@@ -45,8 +48,11 @@ import org.evosuite.utils.Randomness;
 
 /**
  * <p>
- * DSEStrategy class
+ * DSEStrategy class.
  * </p>
+ *
+ * NOTE: even though we are on evosuite, this module is a bit out of context with the GA general framework.
+ *       In the future rebuild it as a standalone library.
  *
  * @author ignacio lebrero
  */
@@ -55,15 +61,20 @@ public class DSEStrategy extends TestGenerationStrategy {
 	public static final String SETTING_UP_DSE_GENERATION_INFO_MESSAGE = "* Setting up DSE test suite generation";
 	public static final String NOT_SOUITALE_METHOD_FOUND_INFO_MESSAGE = "* Found no testable methods in the target class {}";
 
+	/** DSE Stopping conditions */
+	private final MaxTimeStoppingCondition maxTimeStoppingCondition = new MaxTimeStoppingCondition();
+	private final ZeroFitnessStoppingCondition zeroFitnessStoppingCondition = new ZeroFitnessStoppingCondition();
+	private final TargetCoverageReachedStoppingCondition targetCoverageReachedStoppingCondition = new TargetCoverageReachedStoppingCondition();
+
 	@Override
 	public TestSuiteChromosome generateTests() {
 		LoggingUtils.getEvoLogger().info(SETTING_UP_DSE_GENERATION_INFO_MESSAGE);
-		Properties.CRITERION = new Criterion[] { Properties.Criterion.BRANCH };
+		Properties.CRITERION = new Criterion[] { Criterion.LINE };
+		Criterion[] criterion = Properties.CRITERION;
 
 		long startTime = System.currentTimeMillis() / 1000;
 
-		//TODO: move this to a dependency injection schema
-		List<TestFitnessFunction> goals = getFitnessFunctionsGoals(true);
+		List<TestFitnessFunction> goals = FitnessFunctionsUtils.getFitnessFunctionsGoals(criterion, true);
 		if (!canGenerateTestsForSUT()) {
 			LoggingUtils.getEvoLogger().info(
 				NOT_SOUITALE_METHOD_FOUND_INFO_MESSAGE,
@@ -79,7 +90,7 @@ public class DSEStrategy extends TestGenerationStrategy {
 		 */
 		TestSuiteChromosome testSuite = null;
 		if (!(Properties.STOP_ZERO && goals.isEmpty())
-				|| ArrayUtil.contains(Properties.CRITERION, Criterion.EXCEPTION)) {
+				|| ArrayUtil.contains(criterion, Criterion.EXCEPTION)) {
 			// Perform search
 			// This is in case any algorithm internal strategy uses some random behaviour.
 			//     e.g. after x iterations selects the next path randomly.
@@ -87,28 +98,22 @@ public class DSEStrategy extends TestGenerationStrategy {
 			LoggingUtils.getEvoLogger().info("* Starting DSE");
 			ClientServices.getInstance().getClientNode().changeState(ClientState.SEARCH);
 
-			//TODO: move to dependency injection later on
-			DSEAlgorithmFactory dseFactory = new DSEAlgorithmFactory();
-			DSEAlgorithms dseAlgorithmType = Properties.DSE_ALGORITHM_TYPE;
+			// Builds the actual algorithm
+			DSEAlgorithm algorithm = buildDSEAlgorithm();
 
-			LoggingUtils.getEvoLogger().info("* Using DSE algorithm: {}", dseAlgorithmType.getName());
-            DSEAlgorithm algorithm = dseFactory.getDSEAlgorithm(dseAlgorithmType);
-
-			StoppingCondition stoppingCondition = getStoppingCondition();
-
+			// ????
 			if (Properties.STOP_ZERO) {
 
 			}
 
 			testSuite = algorithm.generateSolution();
-
 		} else {
 			testSuite = setNoGoalsCoverage(Properties.DSE_ALGORITHM_TYPE);
 		}
 
 		long endTime = System.currentTimeMillis() / 1000;
 
-		goals = getFitnessFunctionsGoals(false); // recalculated now after the search, eg to
+		goals = FitnessFunctionsUtils.getFitnessFunctionsGoals(criterion, false); // recalculated now after the search, eg to
 									// handle exception fitness
 		ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Total_Goals, goals.size());
 
@@ -133,6 +138,24 @@ public class DSEStrategy extends TestGenerationStrategy {
 
 	}
 
+	private DSEAlgorithm buildDSEAlgorithm() {
+		DSEAlgorithmFactory dseFactory = new DSEAlgorithmFactory();
+		DSEAlgorithms dseAlgorithmType = Properties.DSE_ALGORITHM_TYPE;
+
+		LoggingUtils.getEvoLogger().info("* Using DSE algorithm: {}", dseAlgorithmType.getName());
+		DSEAlgorithm algorithm = dseFactory.getDSEAlgorithm(dseAlgorithmType);
+
+        // Adding stopping conditions
+		algorithm.addStoppingCondition(maxTimeStoppingCondition);
+		algorithm.addStoppingCondition(zeroFitnessStoppingCondition);
+		algorithm.addStoppingCondition(targetCoverageReachedStoppingCondition);
+
+		LoggingUtils.getEvoLogger().debug("* With timeout: {}", Properties.GLOBAL_TIMEOUT);
+		LoggingUtils.getEvoLogger().debug("* With target coverage: {}", Properties.DSE_TARGET_COVERAGE);
+
+		return algorithm;
+	}
+
 	private TestSuiteChromosome setNoGoalsCoverage(DSEAlgorithms algorithm) {
 		TestSuiteChromosome testSuite = new TestSuiteChromosome();;
 		List<TestSuiteFitnessFunction> fitnessFunctions = FitnessFunctionsUtils
@@ -147,47 +170,6 @@ public class DSEStrategy extends TestGenerationStrategy {
 	}
 
 
-	/**
-     * Returns current Fitness functions based on which Properties are currently set.
-     *
-     * @param verbose
-     * @return
-     */
-    private static List<TestFitnessFunction> getFitnessFunctionsGoals(boolean verbose) {
-		List<TestFitnessFactory<? extends TestFitnessFunction>> goalFactories = getFitnessFactories();
-		List<TestFitnessFunction> goals = new ArrayList<>();
 
-		if (goalFactories.size() == 1) {
-			TestFitnessFactory<? extends TestFitnessFunction> factory = goalFactories.iterator().next();
-			goals.addAll(factory.getCoverageGoals());
-
-			if (verbose) {
-				LoggingUtils.getEvoLogger().info("* Total number of test goals: {}", factory.getCoverageGoals().size());
-				if (Properties.PRINT_GOALS) {
-					for (TestFitnessFunction goal : factory.getCoverageGoals())
-						LoggingUtils.getEvoLogger().info("" + goal.toString());
-				}
-			}
-		} else {
-			if (verbose) {
-				LoggingUtils.getEvoLogger().info("* Total number of test goals: ");
-			}
-
-			for (TestFitnessFactory<? extends TestFitnessFunction> goalFactory : goalFactories) {
-				goals.addAll(goalFactory.getCoverageGoals());
-
-				if (verbose) {
-					LoggingUtils.getEvoLogger()
-							.info("  - " + goalFactory.getClass().getSimpleName().replace("CoverageFactory", "") + " "
-									+ goalFactory.getCoverageGoals().size());
-					if (Properties.PRINT_GOALS) {
-						for (TestFitnessFunction goal : goalFactory.getCoverageGoals())
-							LoggingUtils.getEvoLogger().info("" + goal.toString());
-					}
-				}
-			}
-		}
-		return goals;
-	}
 
 }

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithm.java
@@ -172,10 +172,6 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
         // Run & check
         testCasesWorkList.add(initialTestCase);
 
-        // Add new testCase to the testSuite
-        addNewTestCaseToTestSuite(initialTestCase);
-        if (isFinished()) return;
-
         while (keepSearchingCriteriaStrategy.ShouldKeepSearching(testCasesWorkList)) {
             // This gets wrapped into the building and fitness strategy selected due to the PriorityQueue sorting nature
             DSETestCase currentTestCase = testCaseSelectionStrategy.getCurrentIterationBasedTestCase(testCasesWorkList).clone();
@@ -196,6 +192,8 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
             List<DSEPathCondition> children = pathSelectionStrategy.generateChildren(currentExecutedPathCondition);
 
             processChildren(seenChildren, testCasesWorkList, currentTestCase, children);
+
+            notifyIteration();
         }
     }
 
@@ -300,6 +298,8 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
      * @return
      */
      public TestSuiteChromosome generateSolution() {
+         notifyGenerationStarted();
+
 //       Method a  = new Method();
 //       testSuite.addTests(transformResultToChromosome(runDSEAlgorithm(a)));
 
@@ -307,28 +307,10 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
          // TODO: complete, here we can have optimizations like testSuite redundancy reduction.
 
          // Run this before finish
+         notifyGenerationFinished();
          statisticsLogger.logStatistics();
          return testSuite;
      }
-
-    /**
-     * wrapping method till migrate all the GA parts of the algorithm.
-     *
-     * @param testCaseResults
-     * @return
-     */
-    private Collection<TestChromosome> transformResultToChromosome(List<DSETestCase> testCaseResults) {
-        List<TestChromosome> res = new ArrayList<>();
-
-
-        for (DSETestCase t : testCaseResults) {
-            TestChromosome c = new TestChromosome();
-            c.setTestCase(t.getTestCase());
-            res.add(c);
-        }
-
-        return res;
-    }
 
     /**
      * Solves an SMT query

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEAlgorithm.java
@@ -300,8 +300,6 @@ public class DSEAlgorithm extends DSEBaseAlgorithm {
      * @return
      */
      public TestSuiteChromosome generateSolution() {
-         TestSuiteChromosome testSuite = new TestSuiteChromosome();
-
 //       Method a  = new Method();
 //       testSuite.addTests(transformResultToChromosome(runDSEAlgorithm(a)));
 

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
@@ -20,9 +20,9 @@
 package org.evosuite.symbolic.DSE.algorithm;
 
 import org.evosuite.ga.Chromosome;
-import org.evosuite.ga.stoppingconditions.StoppingCondition;
 import org.evosuite.symbolic.DSE.DSEStatistics;
 import org.evosuite.symbolic.DSE.DSETestCase;
+import org.evosuite.symbolic.DSE.algorithm.listener.StoppingCondition;
 import org.evosuite.symbolic.PathCondition;
 import org.evosuite.symbolic.PathConditionUtils;
 import org.evosuite.testcase.TestCase;
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -119,6 +120,75 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 	}
 
 	/**
+	 * <p>
+	 * addStoppingCondition
+	 * </p>
+	 *
+	 * @param condition
+	 *            a {@link org.evosuite.ga.stoppingconditions.StoppingCondition}
+	 *            object.
+	 */
+	public void addStoppingCondition(StoppingCondition condition) {
+		Iterator<StoppingCondition> it = stoppingConditions.iterator();
+		while (it.hasNext()) {
+			if (it.next().getClass().equals(condition.getClass())) {
+				return;
+			}
+		}
+		logger.debug("Adding new stopping condition");
+		stoppingConditions.add(condition);
+	}
+
+	public Set<StoppingCondition> getStoppingConditions() {
+		return stoppingConditions;
+	}
+
+	// TODO: Override equals method in StoppingCondition
+	/**
+	 * <p>
+	 * setStoppingCondition
+	 * </p>
+	 *
+	 * @param condition
+	 *            a {@link org.evosuite.ga.stoppingconditions.StoppingCondition}
+	 *            object.
+	 */
+	public void setStoppingCondition(StoppingCondition condition) {
+		stoppingConditions.clear();
+		logger.debug("Setting stopping condition");
+		stoppingConditions.add(condition);
+	}
+
+	/**
+	 * <p>
+	 * removeStoppingCondition
+	 * </p>
+	 *
+	 * @param condition
+	 *            a {@link org.evosuite.ga.stoppingconditions.StoppingCondition}
+	 *            object.
+	 */
+	public void removeStoppingCondition(StoppingCondition condition) {
+		Iterator<StoppingCondition> it = stoppingConditions.iterator();
+		while (it.hasNext()) {
+			if (it.next().getClass().equals(condition.getClass())) {
+				it.remove();
+			}
+		}
+	}
+
+	/**
+	 * <p>
+	 * resetStoppingConditions
+	 * </p>
+	 */
+	public void resetStoppingConditions() {
+		for (StoppingCondition c : stoppingConditions) {
+			c.reset();
+		}
+	}
+
+	/**
 	 * Determine whether any of the stopping conditions hold
 	 *
 	 * @return a boolean.
@@ -150,6 +220,10 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 		return (double) currentbudget / (double) totalbudget;
 	}
 
+	public TestSuiteChromosome getGeneratedTestSuite() {
+		return testSuite;
+	}
+	
     /**
      * Checks whether the current executed path condition diverged from the original one.
      * TODO: Maybe we can give some info about the PathCondition that diverged later on

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/DSEBaseAlgorithm.java
@@ -202,6 +202,34 @@ public abstract class DSEBaseAlgorithm<T extends Chromosome> {
 	}
 
 	/**
+	 * Notify all search listeners of iteration
+	 */
+	protected void notifyIteration() {
+		for (StoppingCondition stoppingCondition : stoppingConditions) {
+			stoppingCondition.iteration(this);
+		}
+	}
+
+	/**
+	 * Notify all search listeners of search start
+	 */
+	protected void notifyGenerationStarted() {
+		for (StoppingCondition stoppingCondition : stoppingConditions) {
+			stoppingCondition.generationStarted(this);
+		}
+	}
+
+	/**
+	 * Notify all stopping conditions of search end
+	 */
+	protected void notifyGenerationFinished() {
+		for (StoppingCondition stoppingCondition : stoppingConditions) {
+			stoppingCondition.generationFinished(this);
+		}
+	}
+
+
+	/**
 	 * Returns the progress of the search.
 	 *
 	 * @return a value [0.0, 1.0]

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/SearchListener.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/SearchListener.java
@@ -23,7 +23,7 @@ import org.evosuite.ga.Chromosome;
 import org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm;
 
 /**
- * Same SearchListener as the GA algorithm.
+ * Adaptation of {@link org.evosuite.ga.metaheuristics.SearchListener} for the DSE module.
  *
  * @author Ignacio Lebrero
  */
@@ -55,11 +55,4 @@ public interface SearchListener {
 	 * @param individual a {@link org.evosuite.ga.Chromosome} object.
 	 */
 	public void fitnessEvaluation(Chromosome individual);
-
-	/**
-	 * Called before a chromosome is mutated
-	 *
-	 * @param individual a {@link org.evosuite.ga.Chromosome} object.
-	 */
-	public void modification(Chromosome individual);
 }

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/SearchListener.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/SearchListener.java
@@ -33,7 +33,7 @@ public interface SearchListener {
 	 *
 	 * @param algorithm a {@link org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm} object.
 	 */
-	public void searchStarted(DSEBaseAlgorithm algorithm);
+	public void generationStarted(DSEBaseAlgorithm algorithm);
 
 	/**
 	 * Called after each iteration of the search
@@ -47,7 +47,7 @@ public interface SearchListener {
 	 *
 	 * @param algorithm a {@link org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm} object.
 	 */
-	public void searchFinished(DSEBaseAlgorithm algorithm);
+	public void generationFinished(DSEBaseAlgorithm algorithm);
 
 	/**
 	 * Called after every single fitness evaluation

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/SearchListener.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/SearchListener.java
@@ -1,9 +1,33 @@
+/**
+ * Copyright (C) 2010-2020 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.evosuite.symbolic.DSE.algorithm.listener;
 
 import org.evosuite.ga.Chromosome;
 import org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm;
 
-public interface SymbolicExecutionSearchListener {
+/**
+ * Same SearchListener as the GA algorithm.
+ *
+ * @author Ignacio Lebrero
+ */
+public interface SearchListener {
     /**
 	 * Called when a new search is started
 	 *
@@ -24,9 +48,6 @@ public interface SymbolicExecutionSearchListener {
 	 * @param algorithm a {@link org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm} object.
 	 */
 	public void searchFinished(DSEBaseAlgorithm algorithm);
-
-
-    //NOTE: The methods below keeps using the GA Chromosome class as they have what we need for now
 
 	/**
 	 * Called after every single fitness evaluation

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/StoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/StoppingCondition.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2010-2020 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.symbolic.DSE.algorithm.listener;
+
+
+/**
+ * Same StoppingCondition as the GA algorithm.
+ *
+ * @author Ignacio Lebrero
+ */
+public interface StoppingCondition extends SearchListener {
+    /**
+	 * Force a specific amount of used up budget. Handle with care!
+	 *
+	 * @param value
+	 *            The new amount of used up budget for this StoppingCondition
+	 */
+	public abstract void forceCurrentValue(long value);
+
+	/**
+	 * How much of the budget have we used up
+	 *
+	 * @return a long.
+	 */
+	public abstract long getCurrentValue();
+
+	/**
+	 * Get upper limit of resources
+	 *
+	 * Mainly used for toString()
+	 *
+	 * @return limit
+	 */
+	public abstract long getLimit();
+
+	/**
+	 * <p>isFinished</p>
+	 *
+	 * @return a boolean.
+	 */
+	boolean isFinished();
+
+	/**
+	 * Reset everything
+	 */
+	void reset();
+
+	/**
+	 * Set new upper limit of resources
+	 *
+	 * @param limit a long.
+	 */
+	void setLimit(long limit);
+}

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/StoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/StoppingCondition.java
@@ -20,19 +20,14 @@
 package org.evosuite.symbolic.DSE.algorithm.listener;
 
 
+import java.security.InvalidParameterException;
+
 /**
- * Same StoppingCondition as the GA algorithm.
+ * Adaptation of {@link org.evosuite.ga.stoppingconditions.StoppingCondition} for the DSE module.
  *
  * @author Ignacio Lebrero
  */
 public interface StoppingCondition extends SearchListener {
-    /**
-	 * Force a specific amount of used up budget. Handle with care!
-	 *
-	 * @param value
-	 *            The new amount of used up budget for this StoppingCondition
-	 */
-	public abstract void forceCurrentValue(long value);
 
 	/**
 	 * How much of the budget have we used up
@@ -67,5 +62,5 @@ public interface StoppingCondition extends SearchListener {
 	 *
 	 * @param limit a long.
 	 */
-	void setLimit(long limit);
+	void setLimit(long limit) throws InvalidParameterException;
 }

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/StoppingConditionFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/StoppingConditionFactory.java
@@ -1,0 +1,32 @@
+package org.evosuite.symbolic.DSE.algorithm.listener;
+
+import org.evosuite.Properties;
+import org.evosuite.symbolic.DSE.algorithm.listener.implementations.MaxTimeStoppingCondition;
+import org.evosuite.symbolic.DSE.algorithm.listener.implementations.TargetCoverageReachedStoppingCondition;
+import org.evosuite.symbolic.DSE.algorithm.listener.implementations.ZeroFitnessStoppingCondition;
+
+/**
+ * TODO: Move this class to a dependency injection schema.
+ *
+ * @author Ignacio Lebrero
+ */
+public class StoppingConditionFactory {
+
+   	/**
+	 * Convert property to actual stopping condition
+	 * @return
+	 */
+	public static StoppingCondition getStoppingCondition(Properties.DSEStoppingCondition stoppingCondition) {
+		switch (stoppingCondition) {
+		case MAXTIME:
+			return new MaxTimeStoppingCondition();
+        case TARGETCOVERAGE:
+            return new TargetCoverageReachedStoppingCondition();
+        case ZEROFITNESS:
+            return new ZeroFitnessStoppingCondition();
+		default:
+			return new MaxTimeStoppingCondition();
+		}
+	}
+
+}

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/MaxTimeStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/MaxTimeStoppingCondition.java
@@ -18,7 +18,7 @@ public class MaxTimeStoppingCondition extends StoppingConditionImpl {
     private long startTime;
 
     @Override
-    public void searchStarted(DSEBaseAlgorithm algorithm) {
+    public void generationStarted(DSEBaseAlgorithm algorithm) {
         reset();
     }
 

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/MaxTimeStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/MaxTimeStoppingCondition.java
@@ -1,0 +1,51 @@
+package org.evosuite.symbolic.DSE.algorithm.listener.implementations;
+
+import org.evosuite.Properties;
+import org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm;
+
+/**
+ * Taken from {@link org.evosuite.ga.stoppingconditions.MaxTimeStoppingCondition} for using on the DSE module.
+ *
+ * @author Ignacio Lebrero
+ */
+public class MaxTimeStoppingCondition extends StoppingConditionImpl {
+
+    private static final long serialVersionUID = 5262082660819074690L;
+
+	/** Maximum number of seconds */
+    private long maxSeconds = Properties.SEARCH_BUDGET;
+
+    private long startTime;
+
+    @Override
+    public void searchStarted(DSEBaseAlgorithm algorithm) {
+        reset();
+    }
+
+    @Override
+    public long getCurrentValue() {
+        long currentTime = System.currentTimeMillis();
+		return (currentTime - startTime) / 1000;
+    }
+
+    @Override
+    public long getLimit() {
+        return maxSeconds;
+    }
+
+    @Override
+    public boolean isFinished() {
+        long currentTime = System.currentTimeMillis();
+		return (currentTime - startTime) / 1000 > maxSeconds;
+    }
+
+    @Override
+    public void reset() {
+        startTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public void setLimit(long limit) {
+        maxSeconds = limit;
+    }
+}

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/StoppingConditionImpl.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/StoppingConditionImpl.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2010-2020 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.symbolic.DSE.algorithm.listener.implementations;
+
+import org.evosuite.ga.Chromosome;
+import org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm;
+import org.evosuite.symbolic.DSE.algorithm.listener.StoppingCondition;
+
+import java.io.Serializable;
+
+/**
+ * Adaptation of {@link org.evosuite.ga.stoppingconditions.StoppingConditionImpl} for the DSE module.
+ *
+ * @author Ignacio Lebrero
+ */
+public abstract class StoppingConditionImpl implements StoppingCondition, Serializable {
+
+    private static final long serialVersionUID = 6062248039291236657L;
+
+    public StoppingConditionImpl() {
+        reset();
+    }
+
+
+    @Override
+    public void iteration(DSEBaseAlgorithm algorithm) {
+        //Nothing
+    }
+
+    @Override
+    public void searchFinished(DSEBaseAlgorithm algorithm) {
+        //Nothing
+    }
+
+    @Override
+    public void fitnessEvaluation(Chromosome individual) {
+        //Nothing
+    }
+
+    @Override
+    public void searchStarted(DSEBaseAlgorithm algorithm) {
+        //Nothing
+    }
+}

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/StoppingConditionImpl.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/StoppingConditionImpl.java
@@ -45,7 +45,7 @@ public abstract class StoppingConditionImpl implements StoppingCondition, Serial
     }
 
     @Override
-    public void searchFinished(DSEBaseAlgorithm algorithm) {
+    public void generationFinished(DSEBaseAlgorithm algorithm) {
         //Nothing
     }
 
@@ -55,7 +55,7 @@ public abstract class StoppingConditionImpl implements StoppingCondition, Serial
     }
 
     @Override
-    public void searchStarted(DSEBaseAlgorithm algorithm) {
+    public void generationStarted(DSEBaseAlgorithm algorithm) {
         //Nothing
     }
 }

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/TargetCoverageReachedStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/TargetCoverageReachedStoppingCondition.java
@@ -1,0 +1,70 @@
+package org.evosuite.symbolic.DSE.algorithm.listener.implementations;
+
+import org.evosuite.Properties;
+import org.evosuite.ga.Chromosome;
+import org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm;
+
+import java.security.InvalidParameterException;
+
+public class TargetCoverageReachedStoppingCondition extends StoppingConditionImpl {
+
+    private static final long serialVersionUID = 7235280321530441520L;
+
+    /** Bound values for setLimit input */
+    private static final long MINIMUM_LIMIT_INPUT_VALUE = 0;
+    private static final long MAXIMUM_LIMIT_INPUT_VALUE = 100;
+
+    /** Keep track of highest coverage seen so far */
+	private double lastCoverage = Chromosome.MIN_COVERAGE_REACHABLE;
+
+	/** Keep track of the target coverage */
+	private double targetCoverage = Properties.DSE_TARGET_COVERAGE;
+
+    @Override
+    public long getCurrentValue() {
+        return (long) (lastCoverage * MAXIMUM_LIMIT_INPUT_VALUE);
+    }
+
+    @Override
+    public long getLimit() {
+        return (long) (targetCoverage * MAXIMUM_LIMIT_INPUT_VALUE);
+    }
+
+    @Override
+    public boolean isFinished() {
+        return lastCoverage >= targetCoverage;
+    }
+
+    @Override
+    public void reset() {
+        lastCoverage = Chromosome.MIN_COVERAGE_REACHABLE;
+        targetCoverage = Chromosome.MAX_COVERAGE_REACHABLE;
+    }
+
+    /**
+     * Sets the limit of the coverage.
+     *
+     * IMPORTANT: As the values are normalized (between 0 and 1) and the limit
+     *            will arrive as a long value. we have to normalize it.
+     *
+     * @param limit a long.
+     */
+    @Override
+    public void setLimit(long limit) throws InvalidParameterException {
+        if (limit < MINIMUM_LIMIT_INPUT_VALUE || limit > MAXIMUM_LIMIT_INPUT_VALUE) {
+            throw new InvalidParameterException(
+                    "ERROR | limit parameter must be in bounds "
+                            + MINIMUM_LIMIT_INPUT_VALUE
+                            + " and "
+                            + MAXIMUM_LIMIT_INPUT_VALUE
+            );
+        }
+        targetCoverage = (double) limit / 100;
+    }
+
+    @Override
+    public void iteration(DSEBaseAlgorithm algorithm) {
+        lastCoverage = Math.max(lastCoverage, algorithm.getGeneratedTestSuite().getCoverage());
+    }
+
+}

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/ZeroFitnessStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/ZeroFitnessStoppingCondition.java
@@ -1,0 +1,62 @@
+package org.evosuite.symbolic.DSE.algorithm.listener.implementations;
+
+import org.evosuite.ga.Chromosome;
+import org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm;
+import org.evosuite.symbolic.DSE.algorithm.listener.StoppingCondition;
+
+public class ZeroFitnessStoppingCondition implements StoppingCondition {
+    @Override
+    public void forceCurrentValue(long value) {
+
+    }
+
+    @Override
+    public long getCurrentValue() {
+        return 0;
+    }
+
+    @Override
+    public long getLimit() {
+        return 0;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void setLimit(long limit) {
+
+    }
+
+    @Override
+    public void searchStarted(DSEBaseAlgorithm algorithm) {
+
+    }
+
+    @Override
+    public void iteration(DSEBaseAlgorithm algorithm) {
+
+    }
+
+    @Override
+    public void searchFinished(DSEBaseAlgorithm algorithm) {
+
+    }
+
+    @Override
+    public void fitnessEvaluation(Chromosome individual) {
+
+    }
+
+    @Override
+    public void modification(Chromosome individual) {
+
+    }
+}

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/ZeroFitnessStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/ZeroFitnessStoppingCondition.java
@@ -1,18 +1,22 @@
 package org.evosuite.symbolic.DSE.algorithm.listener.implementations;
 
-import org.evosuite.ga.Chromosome;
 import org.evosuite.symbolic.DSE.algorithm.DSEBaseAlgorithm;
-import org.evosuite.symbolic.DSE.algorithm.listener.StoppingCondition;
 
-public class ZeroFitnessStoppingCondition implements StoppingCondition {
-    @Override
-    public void forceCurrentValue(long value) {
+/**
+ * Adaptation of {@link org.evosuite.ga.stoppingconditions.ZeroFitnessStoppingCondition} for the DSE module.
+ *
+ * @author Ignacio Lebrero
+ */
+public class ZeroFitnessStoppingCondition extends StoppingConditionImpl {
 
-    }
+    private static final long serialVersionUID = 6593889710447350828L;
+
+    /** Keep track of lowest fitness seen so far */
+	private double lastFitness = Double.MAX_VALUE;
 
     @Override
     public long getCurrentValue() {
-        return 0;
+        return (long) lastFitness;
     }
 
     @Override
@@ -22,17 +26,17 @@ public class ZeroFitnessStoppingCondition implements StoppingCondition {
 
     @Override
     public boolean isFinished() {
-        return false;
+        return lastFitness <= 0.0;
     }
 
     @Override
     public void reset() {
-
+        lastFitness = Double.MAX_VALUE;
     }
 
     @Override
     public void setLimit(long limit) {
-
+        // Nothing
     }
 
     @Override
@@ -42,21 +46,7 @@ public class ZeroFitnessStoppingCondition implements StoppingCondition {
 
     @Override
     public void iteration(DSEBaseAlgorithm algorithm) {
-
-    }
-
-    @Override
-    public void searchFinished(DSEBaseAlgorithm algorithm) {
-
-    }
-
-    @Override
-    public void fitnessEvaluation(Chromosome individual) {
-
-    }
-
-    @Override
-    public void modification(Chromosome individual) {
-
+        // Why would the new iteration have worst fitness than the previous one????
+        lastFitness = Math.min(lastFitness, algorithm.getGeneratedTestSuite().getFitness());
     }
 }

--- a/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/ZeroFitnessStoppingCondition.java
+++ b/client/src/main/java/org/evosuite/symbolic/DSE/algorithm/listener/implementations/ZeroFitnessStoppingCondition.java
@@ -40,7 +40,7 @@ public class ZeroFitnessStoppingCondition extends StoppingConditionImpl {
     }
 
     @Override
-    public void searchStarted(DSEBaseAlgorithm algorithm) {
+    public void generationStarted(DSEBaseAlgorithm algorithm) {
 
     }
 


### PR DESCRIPTION
# Details
Based on the GA algorithm. Rebuild of stopping conditions for the DSE module. As these are supposed to work with GA objects.

Conditions of DSE:
- Max time 
    - based on the "global time" (by default 60)
- Target coverage 
    - based on  "dse target coverage" (by default 100)
- Zero fitness

# Code
- Parameters
    - Added target coverage
    - Added stopping conditions for DSE
- Abstracted getFitnessFunctionsGoals to FitnessFuncitonsUtils
- Added setup on DSEStrategy.
- Added support to DSEBaseAlgorithm
- Added logic for using them on DSEAlgorithm
- Build interfaces and StoppingConditions for the cases mentioned above.
