### PR TITLE
[Symbolic Engine] Reworked the custom logger + added text files support

### DIFF
--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -483,11 +483,12 @@ public class Properties {
 	public static boolean BYTECODE_LOGGING_ENABLED = false;
 
 	@Parameter(key = "bytecode_logging_mode", group = "DSE", description = "How to log executed bytecode")
-	public static DSEBytecodeLoggingMode BYTECODE_LOGGING_MODE = DSEBytecodeLoggingMode.STANDARD_LOGGING;
+	public static DSEBytecodeLoggingMode BYTECODE_LOGGING_MODE = DSEBytecodeLoggingMode.STD_OUT;
 
-	// TODO (ilebrero): add other modes (i.e. dump to text file)
+	// TODO (ilebrero): add other modes
 	public enum DSEBytecodeLoggingMode {
-		STANDARD_LOGGING
+		STD_OUT,
+		FILE_DUMP
 	}
 
 	// --------- LS ---------

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1065,6 +1065,9 @@ public class Properties {
 	@Parameter(key = "report_dir", group = "Output", description = "Directory in which to put HTML and CSV reports")
 	public static String REPORT_DIR = "evosuite-report";
 
+	@Parameter(key = "bytecode_logging_report_dir", group = "Output", description = "Directory in which to put TXT executed bytecode logs.")
+	public static String BYTECODE_LOGGING_REPORT_DIR = "executed-bytecode-logs";
+
 	@Parameter(key = "output_variables", group = "Output", description = "List of variables to output to CSV file. Variables are separated by commas. Null represents default values")
 	public static String OUTPUT_VARIABLES = null;
 

--- a/client/src/main/java/org/evosuite/dse/AbstractVM.java
+++ b/client/src/main/java/org/evosuite/dse/AbstractVM.java
@@ -1069,6 +1069,11 @@ public abstract class AbstractVM implements IVM {
 				"Should never be called, as ASM redirects all LDC_W calls to LDC.");
 	}
 
+	@Override
+	public void cleanUp() {
+		/* stub */
+	}
+
 	// FIXME: Move this to a better place.
 	static final String[] BYTECODE_NAME = new String[] { "NOP", //$NON-NLS-1$
 			"ACONST_NULL", //$NON-NLS-1$

--- a/client/src/main/java/org/evosuite/dse/IVM.java
+++ b/client/src/main/java/org/evosuite/dse/IVM.java
@@ -611,4 +611,6 @@ public interface IVM {
 	void GOTO_W();
 
 	void JSR_W();
+
+    void cleanUp();
 }

--- a/client/src/main/java/org/evosuite/dse/VM.java
+++ b/client/src/main/java/org/evosuite/dse/VM.java
@@ -121,6 +121,18 @@ public final class VM {
 	}
 
 	/**
+	 * Notifies the VMs that the concolic execution has finished.
+	 * Useful for closing any necessary connections and static states (if any).
+	 *
+	 * TODO (ilebrero): Eventually all VMs can be reused instead of just creating new ones.
+	 */
+	public void cleanUpListeners() {
+		for (IVM listener : this.listeners) {
+			listener.cleanUp();
+		}
+	}
+
+	/**
 	 * This method should be called before {@link #setListeners}. This method
 	 * queues listener ivm to be added to the list of listeners by setListeners.
 	 */

--- a/client/src/main/java/org/evosuite/dse/VM.java
+++ b/client/src/main/java/org/evosuite/dse/VM.java
@@ -178,6 +178,10 @@ public final class VM {
 		 * Listeners are not supposed to throw exceptions to the VM except the
 		 * StopVMException.
 		 */
+
+		// Without differentiating between exceptions, execution is already finished so cleaning up first.
+		vm.cleanUpListeners();
+
 		if (t instanceof StopVMException) {
 			// No more callbacks are done since the list is erased
 			// TODO catch StopVMException in Listeners. Enforce no listener

--- a/client/src/main/java/org/evosuite/symbolic/dse/ConcolicExecutorImpl.java
+++ b/client/src/main/java/org/evosuite/symbolic/dse/ConcolicExecutorImpl.java
@@ -130,6 +130,7 @@ public class ConcolicExecutorImpl implements ConcolicExecutor{
 			TestCaseExecutor.getInstance().setExecutionObservers(originalExecutionObservers);
 		}
 		VM.disableCallBacks(); // ignore all callbacks from now on
+		VM.getInstance().cleanUpListeners();
 
 		List<BranchCondition> branches = pathConditionCollector.getPathCondition();
 		logger.info("Concolic execution ended with " + branches.size() + " branches collected");
@@ -171,7 +172,7 @@ public class ConcolicExecutorImpl implements ConcolicExecutor{
 		listeners.add(new SymbolicFunctionVM(symbolicEnvironment, pathConditionCollector));
 
 		if (Properties.BYTECODE_LOGGING_ENABLED) {
-			listeners.add(new InstructionLoggerVM(symbolicEnvironment));
+			listeners.add(new InstructionLoggerVM());
 		}
 
 		VM.getInstance().setListeners(listeners);

--- a/client/src/main/java/org/evosuite/symbolic/dse/algorithm/ExplorationAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/dse/algorithm/ExplorationAlgorithm.java
@@ -48,6 +48,7 @@ import org.evosuite.testcase.TestCaseUpdater;
 import org.evosuite.testcase.execution.TestCaseExecutor;
 import org.evosuite.testsuite.TestSuiteChromosome;
 import org.evosuite.utils.ClassUtil;
+import org.evosuite.utils.LoggingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,8 +208,12 @@ public abstract class ExplorationAlgorithm extends ExplorationAlgorithmBase {
                   break;
              }
 
-             logger.debug(GENERATING_TESTS_FOR_ENTRY_DEBUG_MESSAGE, entryMethod.getName());
+             LoggingUtils.getEvoLogger().info("* " + GENERATING_TESTS_FOR_ENTRY_DEBUG_MESSAGE, entryMethod.getName());
              int testCaseCount = testSuite.getTests().size();
+
+             /** Setting up current method being targeted */
+             Properties.TARGET_METHOD = entryMethod.getName();
+
              explore(entryMethod);
              int numOfGeneratedTestCases = testSuite.getTests().size() - testCaseCount;
              logger.debug(TESTS_WERE_GENERATED_FOR_ENTRY_METHOD_DEBUG_MESSAGE, numOfGeneratedTestCases, entryMethod.getName());

--- a/client/src/main/java/org/evosuite/symbolic/vm/InstructionLoggerVM.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/InstructionLoggerVM.java
@@ -215,7 +215,12 @@ public class InstructionLoggerVM extends AbstractVM {
 
     protected void CALL_RESULT(Object res) {
         instructionLogger.log("\t ==> ");
-        instructionLogger.logln(res.toString());
+
+        if (res == null) {
+            instructionLogger.logln("null");
+        } else {
+            instructionLogger.logln(res.toString());
+        }
     }
 
     @Override

--- a/client/src/main/java/org/evosuite/symbolic/vm/InstructionLoggerVM.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/InstructionLoggerVM.java
@@ -19,14 +19,11 @@
  */
 package org.evosuite.symbolic.vm;
 
+import org.evosuite.Properties;
 import org.evosuite.dse.AbstractVM;
 import org.evosuite.symbolic.instrument.ConcolicConfig;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.evosuite.symbolic.vm.util.Log.log;
-import static org.evosuite.symbolic.vm.util.Log.logln;
+import org.evosuite.symbolic.vm.instructionlogger.IInstructionLogger;
+import org.evosuite.symbolic.vm.instructionlogger.InstructionLoggerFactory;
 
 /*
     This class is taken and adapted from the DSC tool developed by Christoph Csallner.
@@ -41,19 +38,17 @@ import static org.evosuite.symbolic.vm.util.Log.logln;
  */
 public class InstructionLoggerVM extends AbstractVM {
 
-    private final SymbolicEnvironment environment;
+    private final IInstructionLogger instructionLogger;
 
-    /**
-     * Constructor
-     */
-    public InstructionLoggerVM(SymbolicEnvironment environment) {
-        this.environment = environment;
+    /** Constructor */
+    public InstructionLoggerVM() {
+        this.instructionLogger = InstructionLoggerFactory.getInstance().getInstructionLogger(Properties.BYTECODE_LOGGING_MODE);
     }
 
     @Override
     public void SRC_LINE_NUMBER(int lineNr) {
-        log("\t\t\t\t\tsrc line: ");
-        logln(lineNr);
+        instructionLogger.log("\t\t\t\t\tsrc line: ");
+        instructionLogger.logln(lineNr);
     }
 
     @Override
@@ -98,13 +93,13 @@ public class InstructionLoggerVM extends AbstractVM {
 
     @Override
     public void CALLER_STACK_PARAM(int nr, int calleeLocalsIndex, Object value) {
-        log("callerStackParam ");
-        log(nr);
+        instructionLogger.log("callerStackParam ");
+        instructionLogger.log(nr);
         // TODO: why theres a null value coming here? should that happend?
         if (value != null) {
-            logln(" ", value.toString());
+            instructionLogger.logln(" ", value.toString());
         } else {
-            logln(" ", "null");
+            instructionLogger.logln(" ", "null");
         }
     }
 
@@ -112,11 +107,11 @@ public class InstructionLoggerVM extends AbstractVM {
     @Override
     public void METHOD_BEGIN(int access, String className, String methName, String methDesc) {
         // FIXME: print modifiers (static, public, etc.)
-        log("-------------------", "enter method ");
-        log(className, " ");
-        log(methName, " ");
-        log(methDesc);
-        logln();
+        instructionLogger.log("-------------------", "enter method ");
+        instructionLogger.log(className, " ");
+        instructionLogger.log(methName, " ");
+        instructionLogger.log(methDesc);
+        instructionLogger.logln();
     }
 
     @Override
@@ -161,24 +156,24 @@ public class InstructionLoggerVM extends AbstractVM {
 
     @Override
     public void METHOD_BEGIN_PARAM(int nr, int calleeLocalsIndex, Object value) {
-        log("methodBeginParam ");
-        log(nr);
-        log(" ");
-        log(calleeLocalsIndex);
+        instructionLogger.log("methodBeginParam ");
+        instructionLogger.log(nr);
+        instructionLogger.log(" ");
+        instructionLogger.log(calleeLocalsIndex);
         if (value != null) {
-            logln(" ", value.toString());
+            instructionLogger.logln(" ", value.toString());
         } else {
-            logln(" ", "null");
+            instructionLogger.logln(" ", "null");
         }
     }
 
     @Override
     public void METHOD_BEGIN_RECEIVER(Object value) {
-        log("methodBeginReceiver ");
+        instructionLogger.log("methodBeginReceiver ");
         if (value != null) {
-            logln(" ", value.toString());
+            instructionLogger.logln(" ", value.toString());
         } else {
-            logln(" ", "null");
+            instructionLogger.logln(" ", "null");
         }
     }
 
@@ -219,20 +214,20 @@ public class InstructionLoggerVM extends AbstractVM {
     }
 
     protected void CALL_RESULT(Object res) {
-        log("\t ==> ");
-        logln(res.toString());
+        instructionLogger.log("\t ==> ");
+        instructionLogger.logln(res.toString());
     }
 
     @Override
     public void BB_BEGIN() {
-        logln("---------- basic block");
+        instructionLogger.logln("---------- basic block");
     }
 
     @Override
     public void HANDLER_BEGIN(int access, String className, String methName,
                               String methDesc) {
-        log("---------- handler block in ");
-        logln(className, ".", methName);
+        instructionLogger.log("---------- handler block in ");
+        instructionLogger.logln(className, ".", methName);
     }
 
     /*
@@ -916,7 +911,7 @@ public class InstructionLoggerVM extends AbstractVM {
     } // visitLookupSwitch
 
     protected void exit() {
-        logln("-------------------- exit method");
+        instructionLogger.logln("-------------------- exit method");
     }
 
     @Override
@@ -1085,8 +1080,13 @@ public class InstructionLoggerVM extends AbstractVM {
         logInsn(201);
     }
 
+    @Override
+    public void cleanUp() {
+        instructionLogger.cleanUp();
+    }
+
     protected void logInsn(int opcode) {
-        logln(ConcolicConfig.BYTECODE_NAME[opcode]);
+        instructionLogger.logln(ConcolicConfig.BYTECODE_NAME[opcode]);
 //        logLoopIterations();
     }
 
@@ -1095,81 +1095,81 @@ public class InstructionLoggerVM extends AbstractVM {
     }
 
     protected void logInsn(int opcode, Object p) {
-        log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
+        instructionLogger.log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
         if (p != null) {
-            logln(" ", p.toString());
+            instructionLogger.logln(" ", p.toString());
         } else {
-            logln(" ", "null");
+            instructionLogger.logln(" ", "null");
         }
-//        log(p.toString());
-        logln();
+//        instructionLogger.log(p.toString());
+        instructionLogger.logln();
 //        logLoopIterations();
     }
 
     protected void logInsn(int opcode, Object p1, Object p2) {
-        log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
+        instructionLogger.log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
         if (p1 != null) {
-            logln(p1.toString(), " ");
+            instructionLogger.logln(p1.toString(), " ");
         } else {
-            logln("null", " ");
+            instructionLogger.logln("null", " ");
         }
 
         if (p2 != null) {
-            logln(p2.toString());
+            instructionLogger.logln(p2.toString());
         } else {
-            logln("null");
+            instructionLogger.logln("null");
         }
 
-//        log(p1.toString(), " ");
-//        log(p2.toString());
-        logln();
+//        instructionLogger.log(p1.toString(), " ");
+//        instructionLogger.log(p2.toString());
+        instructionLogger.logln();
 //        logLoopIterations();
     }
 
     protected void logInsn(int opcode, Object p1, Object p2, Object p3) {
-        log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
+        instructionLogger.log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
         if (p1 != null) {
-            logln(p1.toString(), " ");
+            instructionLogger.logln(p1.toString(), " ");
         } else {
-            logln("null", " ");
+            instructionLogger.logln("null", " ");
         }
         if (p2 != null) {
-            logln(p2.toString(), " ");
+            instructionLogger.logln(p2.toString(), " ");
         } else {
-            logln("null", " ");
+            instructionLogger.logln("null", " ");
         }
         if (p3 != null) {
-            logln(p3.toString());
+            instructionLogger.logln(p3.toString());
         } else {
-            logln("null");
+            instructionLogger.logln("null");
         }
-        logln();
+        instructionLogger.logln();
 //        logLoopIterations();
     }
 
     protected void logInsn(int opcode, Object p1, Object p2, Object p3, Object p4) {
-        log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
+        instructionLogger.log(ConcolicConfig.BYTECODE_NAME[opcode], " ");
         if (p1 != null) {
-            logln(p1.toString(), " ");
+            instructionLogger.logln(p1.toString(), " ");
         } else {
-            logln("null", " ");
+            instructionLogger.logln("null", " ");
         }
         if (p2 != null) {
-            logln(p2.toString(), " ");
+            instructionLogger.logln(p2.toString(), " ");
         } else {
-            logln("null", " ");
+            instructionLogger.logln("null", " ");
         }
         if (p3 != null) {
-            logln(p3.toString(), " ");
+            instructionLogger.logln(p3.toString(), " ");
         } else {
-            logln("null", " ");
+            instructionLogger.logln("null", " ");
         }
         if (p4 != null) {
-            logln(p4.toString());
+            instructionLogger.logln(p4.toString());
         } else {
-            logln("null");
+            instructionLogger.logln("null");
         }
-        logln();
+        instructionLogger.logln();
 //        logLoopIterations();
     }
 
@@ -1184,9 +1184,9 @@ public class InstructionLoggerVM extends AbstractVM {
 //
 //        final TObjectIntHashMap<Loop> counts = topFrame().iterationCounts;
 //        for (Loop loop : counts.keys(new Loop[counts.size()])) {
-//            logln("\t" + counts.get(loop) + " " + loop.getHead());
+//            instructionLogger.logln("\t" + counts.get(loop) + " " + loop.getHead());
 //            for (Stmt stmt : loop.getLoopStatements())
-//                logln("\t\t" + stmt);
+//                instructionLogger.logln("\t\t" + stmt);
 //        }
 //    }
 }

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/IInstructionLogger.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/IInstructionLogger.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.symbolic.vm.instructionlogger;
+
+/**
+ * Interface for instruction loggers
+ *
+ * @author Ignacio Lebrero
+ */
+public interface IInstructionLogger {
+
+    /**
+     * Log parameter as p.
+     */
+    void log(int p);
+
+    /**
+     * Log parameter as p.
+     */
+    void log(String p);
+
+    /**
+     * Log newline.
+     */
+    void logln();
+
+    /**
+     * Log parameter as p followed by newline.
+     */
+    void logln(int p);
+
+    /**
+     * Log parameters as ab.
+     */
+    void log(String a, String b);
+
+    /**
+     * Log parameters as abc.
+     */
+    void log(String a, String b, String c);
+
+    /**
+     * Log parameters as abcd.
+     */
+    void log(String a, String b, String c, String d);
+
+    /**
+     * Log parameters as abcde.
+     */
+    void log(String a, String b, String c, String d, String e);
+
+    /**
+     * Log stack trace of exception. If it is an exception thrown by the user
+     * program, omit lower part of stack trace that shows Dsc invocation
+     * machinery.
+     */
+    void logln(Throwable e);
+
+    /**
+     * Log parameter as p followed by newline.
+     */
+    void logln(Object p);
+
+    /**
+     * Log parameter as p followed by newline.
+     */
+    void logln(String p);
+
+    /**
+     * Log parameters as ab followed by newline.
+     */
+    void logln(String a, String b);
+
+    /**
+     * Log parameters as abc followed by newline.
+     */
+    void logln(String a, String b, String c);
+
+    /**
+     * Log parameters as abcd followed by newline.
+     */
+    void logln(String a, String b, String c, String d);
+
+    /**
+     * Log parameters as abcde followed by newline.
+     */
+    void logln(String a, String b, String c, String d, String e);
+
+    void logfileIf(boolean doLog, Object o, String fileName);
+
+    /**
+     * Logs parameter, if doLog.
+     */
+    void logIf(boolean doLog, String s);
+
+    /**
+     * Logs newline, if doLog.
+     */
+    void loglnIf(boolean doLog);
+
+    /**
+     * Logs parameter followed by newline, if doLog.
+     */
+    void loglnIf(boolean doLog, String s);
+
+    /**
+     * Logs parameters as ab followed by newline, if doLog.
+     */
+    void loglnIf(boolean doLog, String a, String b);
+
+    /**
+     * Logs parameters as abc followed by newline, if doLog.
+     */
+    void loglnIf(boolean doLog, String a, String b, String c);
+
+    /**
+     * Logs parameters as abcd followed by newline, if doLog.
+     */
+    void loglnIf(boolean doLog, String a, String b, String c, String d);
+
+    /**
+     * Logs parameters as abcde followed by newline, if doLog.
+     */
+    void loglnIf(boolean doLog, String a, String b, String c, String d, String e);
+
+    /**
+     * Cleans up any internal state
+     */
+    void cleanUp();
+}

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
@@ -51,13 +51,19 @@ public class InstructionLoggerFactory {
 
         switch (bytecodeLoggingMode) {
             case STD_OUT:
-                return new StandardOutputInstructionLogger(SystemPathUtil.buildPath(Properties.TARGET_CLASS, Properties.TARGET_METHOD));
-            case FILE_DUMP:
-                return new FileDumpInstructionLogger(SystemPathUtil.buildFileName(
-                        SystemPathUtil.FileExtension.TXT,
-                        EXECUTED_BYTECODE_FILE_NAME,
+                return new StandardOutputInstructionLogger(SystemPathUtil.buildPath(
                         Properties.TARGET_CLASS,
                         Properties.TARGET_METHOD));
+            case FILE_DUMP:
+                return new FileDumpInstructionLogger(
+                        SystemPathUtil.buildPath(
+                                Properties.REPORT_DIR,
+                                Properties.BYTECODE_LOGGING_REPORT_DIR),
+                        SystemPathUtil.buildFileName(
+                                SystemPathUtil.FileExtension.TXT,
+                                EXECUTED_BYTECODE_FILE_NAME,
+                                Properties.TARGET_CLASS,
+                                Properties.TARGET_METHOD));
             default:
                 throw new IllegalStateException(LOGGING_MODE_NOT_YET_IMPLEMENTED + bytecodeLoggingMode.name());
         }

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
@@ -36,13 +36,30 @@ public class InstructionLoggerFactory {
     public static final String LOGGING_MODE_NOT_PROVIDED = "A logging mode must be provided";
     public static final String LOGGING_MODE_NOT_YET_IMPLEMENTED = "logging mode not yet implemented: ";
 
-    /** Simple Delimiter for path creation */
+    /**
+     * Simple Delimiter for path creation
+     */
     private static final String PATH_DELIMITER = "/";
 
-    /** Simple Delimiter for file creation */
+    /**
+     * Simple Delimiter for file creation
+     */
     private static final String FILE_NAME_DELIMITER = "_";
 
-    /** Singleton instance */
+    /**
+     * Simple Delimiter for file extension
+     */
+    private static final String FILE_EXTENSION_DELIMITER = ".";
+
+    /**
+     * Text files extension
+     */
+    private static final String TEXT_FILE_EXTENSION = "txt";
+
+
+    /**
+     * Singleton instance
+     */
     private static final InstructionLoggerFactory self = new InstructionLoggerFactory();
 
     public static InstructionLoggerFactory getInstance() {
@@ -59,6 +76,7 @@ public class InstructionLoggerFactory {
                 return new StandardOutputInstructionLogger(buildFileName(Properties.TARGET_CLASS, Properties.TARGET_METHOD));
             case FILE_DUMP:
                 return new FileDumpInstructionLogger(buildFilePath(Properties.REPORT_DIR, buildFileName(
+                        TEXT_FILE_EXTENSION,
                         EXECUTED_BYTECODE_FILE_NAME,
                         Properties.TARGET_CLASS,
                         Properties.TARGET_METHOD)));
@@ -74,8 +92,8 @@ public class InstructionLoggerFactory {
      * @param params
      * @return
      */
-    private String buildFileName(String... params) {
-        return joinWithDelimeter(FILE_NAME_DELIMITER, params);
+    private String buildFileName(String extension, String... params) {
+        return joinWithDelimiter(FILE_EXTENSION_DELIMITER, joinWithDelimiter(FILE_NAME_DELIMITER, params), extension);
     }
 
     /**
@@ -86,7 +104,7 @@ public class InstructionLoggerFactory {
      * @return
      */
     private String buildFilePath(String... path) {
-        return joinWithDelimeter(PATH_DELIMITER, path);
+        return joinWithDelimiter(PATH_DELIMITER, path);
     }
 
     /**
@@ -97,7 +115,7 @@ public class InstructionLoggerFactory {
      * @param elements
      * @return
      */
-    private String joinWithDelimeter(String delimiter, String... elements) {
+    private String joinWithDelimiter(String delimiter, String... elements) {
         StringJoiner joiner = new StringJoiner(delimiter);
 
         for (String element : elements) {

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.symbolic.vm.instructionlogger;
+
+import org.evosuite.Properties;
+import org.evosuite.symbolic.vm.instructionlogger.implementations.FileDumpInstructionLogger;
+import org.evosuite.symbolic.vm.instructionlogger.implementations.StandardOutputInstructionLogger;
+
+import java.util.StringJoiner;
+
+import static org.evosuite.symbolic.vm.instructionlogger.implementations.FileDumpInstructionLogger.EXECUTED_BYTECODE_FILE_NAME;
+
+/**
+ * Factory of possible bytecode loggers.
+ *
+ * @author Ignacio Lebrero
+ */
+public class InstructionLoggerFactory {
+    public static final String LOGGING_MODE_NOT_PROVIDED = "A logging mode must be provided";
+    public static final String LOGGING_MODE_NOT_YET_IMPLEMENTED = "logging mode not yet implemented: ";
+
+    /** Simple Delimiter for path creation */
+    private static final String PATH_DELIMITER = "/";
+
+    /** Simple Delimiter for file creation */
+    private static final String FILE_NAME_DELIMITER = "_";
+
+    /** Singleton instance */
+    private static final InstructionLoggerFactory self = new InstructionLoggerFactory();
+
+    public static InstructionLoggerFactory getInstance() {
+        return self;
+    }
+
+    public IInstructionLogger getInstructionLogger(Properties.DSEBytecodeLoggingMode bytecodeLoggingMode) {
+        if (bytecodeLoggingMode == null) {
+            throw new IllegalArgumentException(LOGGING_MODE_NOT_PROVIDED);
+        }
+
+        switch (bytecodeLoggingMode) {
+            case STD_OUT:
+                return new StandardOutputInstructionLogger(buildFileName(Properties.TARGET_CLASS, Properties.TARGET_METHOD));
+            case FILE_DUMP:
+                return new FileDumpInstructionLogger(buildFilePath(Properties.REPORT_DIR, buildFileName(
+                        EXECUTED_BYTECODE_FILE_NAME,
+                        Properties.TARGET_CLASS,
+                        Properties.TARGET_METHOD)));
+            default:
+                throw new IllegalStateException(LOGGING_MODE_NOT_YET_IMPLEMENTED + bytecodeLoggingMode.name());
+        }
+    }
+
+    /**
+     * Creates a file name from a series of given Strings.
+     * TODO(ilebrero): Move this to some "filePathUtils" at some point.
+     *
+     * @param params
+     * @return
+     */
+    private String buildFileName(String... params) {
+        return joinWithDelimeter(FILE_NAME_DELIMITER, params);
+    }
+
+    /**
+     * Creates a path from a series of given Strings.
+     * TODO(ilebrero): Move this to some "filePathUtils" at some point.
+     *
+     * @param path
+     * @return
+     */
+    private String buildFilePath(String... path) {
+        return joinWithDelimeter(PATH_DELIMITER, path);
+    }
+
+    /**
+     * Joins a series of String using a delimiter.
+     * TODO(ilebrero): Move this to some "filePathUtils" at some point.
+     *
+     * @param delimiter
+     * @param elements
+     * @return
+     */
+    private String joinWithDelimeter(String delimiter, String... elements) {
+        StringJoiner joiner = new StringJoiner(delimiter);
+
+        for (String element : elements) {
+            joiner.add(element);
+        }
+
+        return joiner.toString();
+    }
+}

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
@@ -22,8 +22,7 @@ package org.evosuite.symbolic.vm.instructionlogger;
 import org.evosuite.Properties;
 import org.evosuite.symbolic.vm.instructionlogger.implementations.FileDumpInstructionLogger;
 import org.evosuite.symbolic.vm.instructionlogger.implementations.StandardOutputInstructionLogger;
-
-import java.util.StringJoiner;
+import org.evosuite.utils.SystemPathUtil;
 
 import static org.evosuite.symbolic.vm.instructionlogger.implementations.FileDumpInstructionLogger.EXECUTED_BYTECODE_FILE_NAME;
 
@@ -35,27 +34,6 @@ import static org.evosuite.symbolic.vm.instructionlogger.implementations.FileDum
 public class InstructionLoggerFactory {
     public static final String LOGGING_MODE_NOT_PROVIDED = "A logging mode must be provided";
     public static final String LOGGING_MODE_NOT_YET_IMPLEMENTED = "logging mode not yet implemented: ";
-
-    /**
-     * Simple Delimiter for path creation
-     */
-    private static final String PATH_DELIMITER = "/";
-
-    /**
-     * Simple Delimiter for file creation
-     */
-    private static final String FILE_NAME_DELIMITER = "_";
-
-    /**
-     * Simple Delimiter for file extension
-     */
-    private static final String FILE_EXTENSION_DELIMITER = ".";
-
-    /**
-     * Text files extension
-     */
-    private static final String TEXT_FILE_EXTENSION = "txt";
-
 
     /**
      * Singleton instance
@@ -73,55 +51,15 @@ public class InstructionLoggerFactory {
 
         switch (bytecodeLoggingMode) {
             case STD_OUT:
-                return new StandardOutputInstructionLogger(buildFileName(Properties.TARGET_CLASS, Properties.TARGET_METHOD));
+                return new StandardOutputInstructionLogger(SystemPathUtil.buildPath(Properties.TARGET_CLASS, Properties.TARGET_METHOD));
             case FILE_DUMP:
-                return new FileDumpInstructionLogger(buildFilePath(Properties.REPORT_DIR, buildFileName(
-                        TEXT_FILE_EXTENSION,
+                return new FileDumpInstructionLogger(SystemPathUtil.buildFileName(
+                        SystemPathUtil.FileExtension.TXT,
                         EXECUTED_BYTECODE_FILE_NAME,
                         Properties.TARGET_CLASS,
-                        Properties.TARGET_METHOD)));
+                        Properties.TARGET_METHOD));
             default:
                 throw new IllegalStateException(LOGGING_MODE_NOT_YET_IMPLEMENTED + bytecodeLoggingMode.name());
         }
-    }
-
-    /**
-     * Creates a file name from a series of given Strings.
-     * TODO(ilebrero): Move this to some "filePathUtils" at some point.
-     *
-     * @param params
-     * @return
-     */
-    private String buildFileName(String extension, String... params) {
-        return joinWithDelimiter(FILE_EXTENSION_DELIMITER, joinWithDelimiter(FILE_NAME_DELIMITER, params), extension);
-    }
-
-    /**
-     * Creates a path from a series of given Strings.
-     * TODO(ilebrero): Move this to some "filePathUtils" at some point.
-     *
-     * @param path
-     * @return
-     */
-    private String buildFilePath(String... path) {
-        return joinWithDelimiter(PATH_DELIMITER, path);
-    }
-
-    /**
-     * Joins a series of String using a delimiter.
-     * TODO(ilebrero): Move this to some "filePathUtils" at some point.
-     *
-     * @param delimiter
-     * @param elements
-     * @return
-     */
-    private String joinWithDelimiter(String delimiter, String... elements) {
-        StringJoiner joiner = new StringJoiner(delimiter);
-
-        for (String element : elements) {
-            joiner.add(element);
-        }
-
-        return joiner.toString();
     }
 }

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/AbstractInstructionLogger.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/AbstractInstructionLogger.java
@@ -17,14 +17,14 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.evosuite.symbolic.vm.util;
+package org.evosuite.symbolic.vm.instructionlogger.implementations;
 
+import org.evosuite.symbolic.vm.instructionlogger.IInstructionLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,9 +44,9 @@ import java.util.List;
  *
  * @author csallner@uta.edu (Christoph Csallner)
  */
-public abstract class Log {
+public abstract class AbstractInstructionLogger implements IInstructionLogger {
 
-    private static final transient Logger logger = LoggerFactory.getLogger(Log.class);
+    private static final transient Logger logger = LoggerFactory.getLogger(AbstractInstructionLogger.class);
     static List<String> instructionsExecuted = new ArrayList();
     static StringBuilder buffer = new StringBuilder();
 
@@ -54,49 +54,28 @@ public abstract class Log {
     public final static String FS = System.getProperty("file.separator");
 
     /**
-     * FIXME: need a logging system
-     */
-    protected final static PrintStream out = System.out;
-
-
-    /**
      * Log parameter as p.
      */
-    public static void log(int p) {
-        logger.info(String.valueOf(p));
-        buffer.append(p + " ");
-    }
-
-    /**
-     * Log parameter as p.
-     */
-    public static void log(String p) {
-        logger.info(p);
-        buffer.append(p + " ");
-    }
+    public abstract void log(String p);
 
     /**
      * Log newline.
      */
-    public static void logln() {
-        logger.info("");
-        instructionsExecuted.add(buffer.toString());
-        buffer = new StringBuilder();
-    }
+    public abstract void logln();
+
+    public abstract void cleanUp();
 
     /**
-     * Log parameter as p followed by newline.
+     * Log parameter as p.
      */
-    public static void logln(int p) {
-        logger.info(String.valueOf(p));
-        buffer.append(p + " ");
-        logln();
+    public void log(int p) {
+        log(String.valueOf(p));
     }
 
     /**
      * Log parameters as ab.
      */
-    public static void log(String a, String b) {
+    public void log(String a, String b) {
         log(a);
         log(b);
     }
@@ -104,7 +83,7 @@ public abstract class Log {
     /**
      * Log parameters as abc.
      */
-    public static void log(String a, String b, String c) {
+    public void log(String a, String b, String c) {
         log(a);
         log(b);
         log(c);
@@ -113,7 +92,7 @@ public abstract class Log {
     /**
      * Log parameters as abcd.
      */
-    public static void log(String a, String b, String c, String d) {
+    public void log(String a, String b, String c, String d) {
         log(a);
         log(b);
         log(c);
@@ -123,7 +102,7 @@ public abstract class Log {
     /**
      * Log parameters as abcde.
      */
-    public static void log(String a, String b, String c, String d, String e) {
+    public void log(String a, String b, String c, String d, String e) {
         log(a);
         log(b);
         log(c);
@@ -132,11 +111,19 @@ public abstract class Log {
     }
 
     /**
+     * Log parameter as p followed by newline.
+     */
+    public void logln(int p) {
+        log(p);
+        logln();
+    }
+
+    /**
      * Log stack trace of exception. If it is an exception thrown by the user
      * program, omit lower part of stack trace that shows Dsc invocation
      * machinery.
      */
-    public static void logln(Throwable e) {
+    public void logln(Throwable e) {
         if (e == null)
             return;
 
@@ -165,14 +152,14 @@ public abstract class Log {
     /**
      * Log parameter as p followed by newline.
      */
-    public static void logln(Object p) {
+    public void logln(Object p) {
         logln(p.toString());
     }
 
     /**
      * Log parameter as p followed by newline.
      */
-    public static void logln(String p) {
+    public void logln(String p) {
         logger.info(p);
         logln();
     }
@@ -180,7 +167,7 @@ public abstract class Log {
     /**
      * Log parameters as ab followed by newline.
      */
-    public static void logln(String a, String b) {
+    public void logln(String a, String b) {
         log(a, b);
         logln();
     }
@@ -188,7 +175,7 @@ public abstract class Log {
     /**
      * Log parameters as abc followed by newline.
      */
-    public static void logln(String a, String b, String c) {
+    public void logln(String a, String b, String c) {
         log(a, b, c);
         logln();
     }
@@ -196,7 +183,7 @@ public abstract class Log {
     /**
      * Log parameters as abcd followed by newline.
      */
-    public static void logln(String a, String b, String c, String d) {
+    public void logln(String a, String b, String c, String d) {
         log(a, b, c, d);
         logln();
     }
@@ -204,12 +191,12 @@ public abstract class Log {
     /**
      * Log parameters as abcde followed by newline.
      */
-    public static void logln(String a, String b, String c, String d, String e) {
+    public void logln(String a, String b, String c, String d, String e) {
         log(a, b, c, d, e);
         logln();
     }
 
-    public static void logfileIf(boolean doLog, Object o, String fileName) {
+    public void logfileIf(boolean doLog, Object o, String fileName) {
         if (!doLog)    // src-util should not depend on src-vm
             return;
 
@@ -226,7 +213,7 @@ public abstract class Log {
     /**
      * Logs parameter, if doLog.
      */
-    public static void logIf(boolean doLog, String s) {
+    public void logIf(boolean doLog, String s) {
         if (doLog)
             log(s);
     }
@@ -235,7 +222,7 @@ public abstract class Log {
     /**
      * Logs newline, if doLog.
      */
-    public static void loglnIf(boolean doLog) {
+    public void loglnIf(boolean doLog) {
         if (doLog)
             logln();
     }
@@ -243,7 +230,7 @@ public abstract class Log {
     /**
      * Logs parameter followed by newline, if doLog.
      */
-    public static void loglnIf(boolean doLog, String s) {
+    public void loglnIf(boolean doLog, String s) {
         if (doLog)
             logln(s);
     }
@@ -251,7 +238,7 @@ public abstract class Log {
     /**
      * Logs parameters as ab followed by newline, if doLog.
      */
-    public static void loglnIf(boolean doLog, String a, String b) {
+    public void loglnIf(boolean doLog, String a, String b) {
         if (doLog)
             logln(a, b);
     }
@@ -259,7 +246,7 @@ public abstract class Log {
     /**
      * Logs parameters as abc followed by newline, if doLog.
      */
-    public static void loglnIf(boolean doLog, String a, String b, String c) {
+    public void loglnIf(boolean doLog, String a, String b, String c) {
         if (doLog)
             logln(a, b, c);
     }
@@ -267,7 +254,7 @@ public abstract class Log {
     /**
      * Logs parameters as abcd followed by newline, if doLog.
      */
-    public static void loglnIf(boolean doLog, String a, String b, String c, String d) {
+    public void loglnIf(boolean doLog, String a, String b, String c, String d) {
         if (doLog)
             logln(a, b, c, d);
     }
@@ -275,7 +262,7 @@ public abstract class Log {
     /**
      * Logs parameters as abcde followed by newline, if doLog.
      */
-    public static void loglnIf(boolean doLog, String a, String b, String c, String d, String e) {
+    public void loglnIf(boolean doLog, String a, String b, String c, String d, String e) {
         if (doLog)
             logln(a, b, c, d, e);
     }

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/FileDumpInstructionLogger.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/FileDumpInstructionLogger.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.symbolic.vm.instructionlogger.implementations;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * Instruction Logger that outputs through a text file.
+ *
+ * @author Ignacio Lebrero
+ */
+public final class FileDumpInstructionLogger extends AbstractInstructionLogger {
+
+    private static final Logger logger = LoggerFactory.getLogger(FileDumpInstructionLogger.class);
+    public static final String EXECUTED_BYTECODE_FILE_NAME = "executedBytecode.txt";
+
+
+    private String filename;
+    private FileWriter fstream;
+    private BufferedWriter writer;
+
+    public FileDumpInstructionLogger(String filename) {
+        this.filename = filename;
+
+        try {
+            this.fstream = new FileWriter(filename);
+            this.writer = new BufferedWriter(this.fstream);
+        } catch (IOException e) {
+            logger.error("Error when opening file " + filename);
+            logger.error(e.getMessage());
+        }
+    }
+
+    @Override
+    public void log(String p) {
+        try {
+            writer.write(p);
+        } catch (IOException e) {
+            logger.error("Error when trying to write: " + p);
+            logger.error(e.getMessage());
+        }
+    }
+
+    @Override
+    public void logln() {
+        try {
+            writer.write("\n");
+        } catch (IOException e) {
+            logger.error("Error when trying to write a new line");
+            logger.error(e.getMessage());
+        }
+    }
+
+    @Override
+    public void cleanUp() {
+        try {
+            writer.close();
+            fstream.close();
+        } catch (IOException e) {
+            logger.error("Error when trying to close file " + filename);
+            logger.error(e.getMessage());
+        }
+    }
+}

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/FileDumpInstructionLogger.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/FileDumpInstructionLogger.java
@@ -34,8 +34,7 @@ import java.io.IOException;
 public final class FileDumpInstructionLogger extends AbstractInstructionLogger {
 
     private static final Logger logger = LoggerFactory.getLogger(FileDumpInstructionLogger.class);
-    public static final String EXECUTED_BYTECODE_FILE_NAME = "executedBytecode.txt";
-
+    public static final String EXECUTED_BYTECODE_FILE_NAME = "executedBytecode";
 
     private String filename;
     private FileWriter fstream;

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/FileDumpInstructionLogger.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/FileDumpInstructionLogger.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
 
 /**
  * Instruction Logger that outputs through a text file.
@@ -39,6 +40,7 @@ public final class FileDumpInstructionLogger extends AbstractInstructionLogger {
     private String filename;
     private FileWriter fstream;
     private BufferedWriter writer;
+    private PrintWriter pw;
 
     public FileDumpInstructionLogger(String filename) {
         this.filename = filename;
@@ -46,6 +48,7 @@ public final class FileDumpInstructionLogger extends AbstractInstructionLogger {
         try {
             this.fstream = new FileWriter(filename);
             this.writer = new BufferedWriter(this.fstream);
+            this.pw = new PrintWriter(this.writer);
         } catch (IOException e) {
             logger.error("Error when opening file " + filename);
             logger.error(e.getMessage());
@@ -54,27 +57,18 @@ public final class FileDumpInstructionLogger extends AbstractInstructionLogger {
 
     @Override
     public void log(String p) {
-        try {
-            writer.write(p);
-        } catch (IOException e) {
-            logger.error("Error when trying to write: " + p);
-            logger.error(e.getMessage());
-        }
+        pw.print(p);
     }
 
     @Override
     public void logln() {
-        try {
-            writer.write("\n");
-        } catch (IOException e) {
-            logger.error("Error when trying to write a new line");
-            logger.error(e.getMessage());
-        }
+        pw.println();
     }
 
     @Override
     public void cleanUp() {
         try {
+            pw.close();
             writer.close();
             fstream.close();
         } catch (IOException e) {

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/StandardOutputInstructionLogger.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/implementations/StandardOutputInstructionLogger.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.symbolic.vm.instructionlogger.implementations;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Instruction Logger that outputs through the standard logger.
+ *
+ * @author Ignacio Lebrero
+ */
+public final class StandardOutputInstructionLogger extends AbstractInstructionLogger {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractInstructionLogger.class);
+
+    private final String prefix;
+
+    public StandardOutputInstructionLogger(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /**
+     * Log parameter as p.
+     */
+    @Override
+    public void log(String p) {
+        /** ilebero: this could be done using MDC or some other pattern? this is the only place we actually use it */
+        logger.info(prefix + " | " + p);
+        buffer.append(p + " ");
+    }
+
+    /**
+     * Log newline.
+     */
+    @Override
+    public void logln() {
+        logger.info("");
+        instructionsExecuted.add(buffer.toString());
+        buffer = new StringBuilder();
+    }
+
+    @Override
+    public void cleanUp() {
+        /** Nothing to do here */
+    }
+
+}

--- a/client/src/main/java/org/evosuite/utils/SystemPathUtil.java
+++ b/client/src/main/java/org/evosuite/utils/SystemPathUtil.java
@@ -56,12 +56,12 @@ public class SystemPathUtil {
     /**
      * Simple Delimiter for file creation
      */
-    private static final String FILE_NAME_DELIMITER = "_";
+    public static final String FILE_NAME_DELIMITER = "_";
 
     /**
      * Simple Delimiter for file extension
      */
-    private static final String FILE_EXTENSION_DELIMITER = ".";
+    public static final String FILE_EXTENSION_DELIMITER = ".";
 
 
     /**

--- a/client/src/main/java/org/evosuite/utils/SystemPathUtil.java
+++ b/client/src/main/java/org/evosuite/utils/SystemPathUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.utils;
+
+import java.io.File;
+import java.util.StringJoiner;
+
+/**
+ * Utils for files/directories paths creation.
+ *
+ * @author Ignacio Lebrero
+ */
+public class SystemPathUtil {
+
+    /**
+     * Exceptions messages
+     */
+    public static final String ELEMENTS_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE = "Elements must not be null.";
+    public static final String DELIMITER_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE = "Delimiter must not be null.";
+
+    /**
+     * Different file extensions
+     */
+    public enum FileExtension {
+        TXT("txt"),
+        CSV("csv");
+
+        String name;
+
+        FileExtension(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+    }
+
+    /**
+     * Simple Delimiter for file creation
+     */
+    private static final String FILE_NAME_DELIMITER = "_";
+
+    /**
+     * Simple Delimiter for file extension
+     */
+    private static final String FILE_EXTENSION_DELIMITER = ".";
+
+
+    /**
+     * Creates a file name from a series of given Strings.
+     *
+     * @param params
+     * @return
+     */
+    public static String buildFileName(FileExtension extension, String... params) {
+        return joinWithDelimiter(FILE_EXTENSION_DELIMITER, joinWithDelimiter(FILE_NAME_DELIMITER, params), extension.getName());
+    }
+
+    /**
+     * Creates a path from a series of given Strings.
+     *
+     * @param pathElements
+     * @return
+     */
+    public static String buildPath(String... pathElements) {
+        return joinWithDelimiter(File.separator, pathElements);
+    }
+
+    /**
+     * Joins a series of String using a delimiter.
+     *
+     * @param delimiter
+     * @param elements
+     * @return
+     */
+    public static String joinWithDelimiter(String delimiter, String... elements) {
+        if (delimiter == null) throw new IllegalArgumentException(DELIMITER_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE);
+        if (elements == null) throw new IllegalArgumentException(ELEMENTS_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE);
+
+        StringJoiner joiner = new StringJoiner(delimiter);
+
+        for (String element : elements) {
+            joiner.add(element);
+        }
+
+        return joiner.toString();
+    }
+}

--- a/client/src/test/java/org/evosuite/utils/SystemPathUtilTest.java
+++ b/client/src/test/java/org/evosuite/utils/SystemPathUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.evosuite.utils.SystemPathUtil.DELIMITER_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE;
+import static org.evosuite.utils.SystemPathUtil.ELEMENTS_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Ignacio Lebrero
+ */
+public class SystemPathUtilTest {
+
+    @Test
+    public void testJoinWithDelimiter() {
+        String a = "element1";
+        String b = "element2";
+        String c = "element3";
+
+        Assert.assertEquals("element1_element2_element3", SystemPathUtil.joinWithDelimiter("_", a, b, c));
+    }
+
+    @Test
+    public void testJoinWithDelimiterEmptyDelimiter() {
+        String a = "element1";
+        String b = "element2";
+        String c = "element3";
+
+        Assert.assertEquals("element1element2element3", SystemPathUtil.joinWithDelimiter("", a, b, c));
+    }
+
+    @Test
+    public void testJoinWithDelimiterNullDelimiter() {
+        String a = "element1";
+        String b = "element2";
+        String c = "element3";
+        boolean exceptionThrown = false;
+
+        try {
+            SystemPathUtil.joinWithDelimiter(null, a, b, c);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().equals(DELIMITER_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE)) {
+                exceptionThrown = true;
+            }
+        }
+
+        assertTrue(exceptionThrown);
+    }
+
+        @Test
+    public void testJoinWithDelimiterNullElements() {
+        boolean exceptionThrown = false;
+
+        try {
+            SystemPathUtil.joinWithDelimiter("_", null);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().equals(ELEMENTS_MUST_NOT_BE_NULL_EXCEPTION_MESSAGE)) {
+                exceptionThrown = true;
+            }
+        }
+
+        assertTrue(exceptionThrown);
+    }
+
+    @Test
+    public void testJoinWithDelimiterEmptyString() {
+        Assert.assertEquals("", SystemPathUtil.joinWithDelimiter("_"));
+    }
+}


### PR DESCRIPTION
# Details

Improved the InstructionLoggerVM [previously created](https://github.com/ilebrero/evosuite/pull/24) for managing both std output and text files dumping. This is useful for debugging weird errors when the symbolic environment gets inconsistent.

# Changes

- Added a *clean up* stage to the VMs in order to close / clean any resource / left state needed. This is useful if at some point we decide to reuse any VM and not re create them each time a concolic execution is made.
- Added a standard and file dumping bytecode loggers. For now the file has the format `executedBytecode_<SUTClassName>_<SUTMethodName>.txt`