### PR TITLE
Symbolic Engine - JDK 9 Support | Benchmarks

### DIFF
--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -449,6 +449,11 @@ public class Properties {
 		SUITE;
 	}
 
+	// NOTE (ilebrero): This is the current method name being explored. This is NOT a good practice, but it's
+	//	     the only way I can imagine to get the current method name for saving the bytecodeLogging info in a file.
+	//		 TODO: Is there a better way of doing this?
+	public static String CURRENT_TARGET_METHOD = "";
+
     // NOTE: by default we use the sage implementation of the algorithm
 	@Parameter(key = "dse_algorithm", group = "DSE", description = "Type of DSE algorithm to use.")
 	public static DSEAlgorithms DSE_ALGORITHM_TYPE = DSEAlgorithms.SAGE;

--- a/client/src/main/java/org/evosuite/symbolic/dse/algorithm/ExplorationAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/dse/algorithm/ExplorationAlgorithm.java
@@ -102,7 +102,7 @@ public abstract class ExplorationAlgorithm extends ExplorationAlgorithmBase {
     public static final String STRATEGY_CANNOT_BE_NULL                                       = "Strategy cannot be null";
     public static final String ENTRY_POINTS_FOUND_DEBUG_MESSAGE                              = "Found {} as entry points for DSE";
     public static final String STOPPING_CONDITION_MET_DEBUG_MESSAGE                          = "A stopping condition was met. No more tests can be generated using DSE.";
-    public static final String GENERATING_TESTS_FOR_ENTRY_DEBUG_MESSAGE                      = "Generating tests for entry method {}";
+    public static final String GENERATING_TESTS_FOR_ENTRY_DEBUG_MESSAGE                      = "Generating tests for entry method: {}";
     public static final String TESTS_WERE_GENERATED_FOR_ENTRY_METHOD_DEBUG_MESSAGE           = "{} tests were generated for entry method {}";
     public static final String EXPLORATION_STRATEGIES_MUST_BE_INITIALIZED_TO_START_SEARCHING = "Exploration strategies must be initialized to start searching.";
 

--- a/client/src/main/java/org/evosuite/symbolic/dse/algorithm/ExplorationAlgorithm.java
+++ b/client/src/main/java/org/evosuite/symbolic/dse/algorithm/ExplorationAlgorithm.java
@@ -212,7 +212,7 @@ public abstract class ExplorationAlgorithm extends ExplorationAlgorithmBase {
              int testCaseCount = testSuite.getTests().size();
 
              /** Setting up current method being targeted */
-             Properties.TARGET_METHOD = entryMethod.getName();
+             Properties.CURRENT_TARGET_METHOD = entryMethod.getName();
 
              explore(entryMethod);
              int numOfGeneratedTestCases = testSuite.getTests().size() - testCaseCount;

--- a/client/src/main/java/org/evosuite/symbolic/vm/CallVM.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/CallVM.java
@@ -1002,9 +1002,13 @@ public final class CallVM extends AbstractVM {
 			return false;
 
 		/* virtual method */
-
-		if (method.getDeclaringClass().isAnonymousClass()) {
-			// anonymous class
+		/** NOTE (ilebrero): are there other cases like this? */
+		/** TODO (ilebrero): Create a special case for local and anonymous classes goal tracking for DSE. So far,
+		 * 					 evosuite is skipping tracking those, even though in DSE they are symbolized and tests are
+		 * 					 created (In fact, they are being dropped by TestSuiteMinizer for not finding goals that
+		 * 					 they cover). */
+		if (method.getDeclaringClass().isAnonymousClass() || method.getDeclaringClass().isLocalClass()) {
+			// anonymous or local class
 			String name = method.getDeclaringClass().getName();
 			int indexOf = name.indexOf("$");
 			String fullyQualifiedTopLevelClassName = name.substring(0, indexOf);

--- a/client/src/main/java/org/evosuite/symbolic/vm/CallVM.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/CallVM.java
@@ -34,7 +34,6 @@ import org.evosuite.symbolic.instrument.ConcolicInstrumentingClassLoader;
 import org.evosuite.symbolic.instrument.ConcolicMethodAdapter;
 import org.evosuite.symbolic.vm.heap.SymbolicHeap;
 import org.evosuite.symbolic.vm.string.Types;
-import org.evosuite.utils.LoggingUtils;
 import org.objectweb.asm.Type;
 
 import java.lang.reflect.Constructor;
@@ -252,15 +251,9 @@ public final class CallVM extends AbstractVM {
 		final Deque<Operand> params = new LinkedList<>();
 		Iterator<Operand> it = env.topFrame().operandStack.iterator();
 
-		LoggingUtils.getEvoLogger().info("Entre con clase -> " + className);
-		LoggingUtils.getEvoLogger().info("Entre con metodo -> " + methName);
-		LoggingUtils.getEvoLogger().info("Entre con descriptor -> " + methDesc);
-		LoggingUtils.getEvoLogger().info("I'm expecting how much? -> " + (paramTypes.length - 1));
-
 		for (int i = paramTypes.length - 1; i >= 0; i--) {
 			// read parameters from caller operand srack
 			Operand param = it.next();
-			LoggingUtils.getEvoLogger().info("Levanto el parametro -> " + param.toString());
 			params.push(param);
 		}
 

--- a/client/src/main/java/org/evosuite/symbolic/vm/OperandUtils.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/OperandUtils.java
@@ -20,6 +20,9 @@
 package org.evosuite.symbolic.vm;
 
 import org.evosuite.symbolic.expr.Expression;
+import org.evosuite.symbolic.expr.bv.IntegerValue;
+import org.evosuite.symbolic.expr.fp.RealValue;
+import org.evosuite.symbolic.expr.ref.ReferenceExpression;
 
 /**
  * @author Ilebrero
@@ -38,6 +41,21 @@ public class OperandUtils {
 			return referenceOperand.getReference();
 		} else {
 			throw new IllegalStateException("Unexpected operandType: " + operand.getClass().getName() + " is not a supported operand.");
+		}
+	}
+
+	public static Operand expressionToOperand(Expression expression) {
+		if (expression instanceof IntegerValue) {
+			IntegerValue intExpression = (IntegerValue) expression;
+			return new Bv64Operand(intExpression);
+		} else if (expression instanceof RealValue) {
+			RealValue realExpression = (RealValue) expression;
+			return new Fp64Operand(realExpression);
+		} else if (expression instanceof ReferenceExpression) {
+			ReferenceExpression referenceExpression = (ReferenceExpression) expression;
+			return new ReferenceOperand(referenceExpression);
+		} else {
+			throw new IllegalStateException("Unexpected expression type: " + expression.getClass().getName() + " is not a supported operand.");
 		}
 	}
 

--- a/client/src/main/java/org/evosuite/symbolic/vm/heap/SymbolicHeap.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/heap/SymbolicHeap.java
@@ -148,7 +148,11 @@ public final class SymbolicHeap {
 			Expression<?> symb_value) {
 
 		Map<ReferenceExpression, Expression<?>> symb_field = getOrCreateSymbolicField(className, fieldName);
-		if (symb_value == null || !symb_value.containsSymbolicVariable()) {
+
+		// NOTE (ilebrero): We need to store elements even if they are constant due to probable usage later on of their
+		//					reference (i.e. if the reference is bounded to an object like a closure.)
+		//		if (symb_value == null || !symb_value.containsSymbolicVariable()) {
+		if (symb_value == null) {
 			symb_field.remove(symb_receiver);
 		} else {
 			symb_field.put(symb_receiver, symb_value);
@@ -172,7 +176,11 @@ public final class SymbolicHeap {
 			ReferenceExpression symb_value) {
 
 		Map<ReferenceExpression, Expression<?>> symb_field = getOrCreateSymbolicField(className, fieldName);
-		if (symb_value == null || !symb_value.containsSymbolicVariable()) {
+
+		// NOTE (ilebrero): We need to store elements even if they are constant due to probable usage later on of their
+		//					reference (i.e. if the reference is bounded to an object like a closure.)
+		//		if (symb_value == null || !symb_value.containsSymbolicVariable()) {
+		if (symb_value == null) {
 			symb_field.remove(symb_receiver);
 		} else {
 			symb_field.put(symb_receiver, symb_value);

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
@@ -63,7 +63,7 @@ public class InstructionLoggerFactory {
                                 SystemPathUtil.FileExtension.TXT,
                                 EXECUTED_BYTECODE_FILE_NAME,
                                 Properties.TARGET_CLASS,
-                                Properties.TARGET_METHOD));
+                                Properties.CURRENT_TARGET_METHOD));
             default:
                 throw new IllegalStateException(LOGGING_MODE_NOT_YET_IMPLEMENTED + bytecodeLoggingMode.name());
         }

--- a/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/instructionlogger/InstructionLoggerFactory.java
@@ -53,7 +53,7 @@ public class InstructionLoggerFactory {
             case STD_OUT:
                 return new StandardOutputInstructionLogger(SystemPathUtil.buildPath(
                         Properties.TARGET_CLASS,
-                        Properties.TARGET_METHOD));
+                        Properties.CURRENT_TARGET_METHOD));
             case FILE_DUMP:
                 return new FileDumpInstructionLogger(
                         SystemPathUtil.buildPath(

--- a/master/src/test/java/com/examples/with/different/packagename/dse/LocalClassExample.java
+++ b/master/src/test/java/com/examples/with/different/packagename/dse/LocalClassExample.java
@@ -1,0 +1,23 @@
+package com.examples.with.different.packagename.dse;
+
+/**
+ * Simple example of local class usage
+ *
+ * @author Ignacio Lebrero
+ */
+public class LocalClassExample {
+    public static int validateNumber(int number) {
+
+        class numberChecker {
+            public int isArbitraryNumber(int number) {
+                if (number == 48576693)
+                    return 1;
+                else
+                    return 0;
+            }
+        }
+
+        numberChecker myNumber = new numberChecker();
+        return myNumber.isArbitraryNumber(number);
+    }
+}

--- a/master/src/test/java/com/examples/with/different/packagename/dse/invokedynamic/ClosureField.java
+++ b/master/src/test/java/com/examples/with/different/packagename/dse/invokedynamic/ClosureField.java
@@ -1,0 +1,28 @@
+package com.examples.with.different.packagename.dse.invokedynamic;
+
+import java.util.function.Function;
+
+/**
+ * Simple example of closures as fields.
+ *
+ * Here the method descriptor of the call made in test will differ from the one
+ * used when begging executing the closure (intCompare).
+ *
+ * See the resulting bytecode for more information.
+ *
+ * @author Ignacio Lebrero
+ */
+class ClosureField {
+    public Function<Integer, Boolean> intCompare;
+
+    public ClosureField() {
+        // Closure lambda.
+        Integer y = new Integer(12);
+        Integer z = new Integer(22);
+        this.intCompare = x -> (x > y && x < z);
+    }
+
+    boolean test(int x) {
+        return this.intCompare.apply(new Integer(x));
+    }
+}

--- a/master/src/test/java/com/examples/with/different/packagename/dse/invokedynamic/ClosureFieldTest.java
+++ b/master/src/test/java/com/examples/with/different/packagename/dse/invokedynamic/ClosureFieldTest.java
@@ -1,0 +1,13 @@
+package com.examples.with.different.packagename.dse.invokedynamic;
+
+public class ClosureFieldTest {
+    public static int test(int x) {
+        ClosureField a = new ClosureField();
+
+        if (a.test(x)) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+}

--- a/master/src/test/java/com/examples/with/different/packagename/dse/invokedynamic/InvokeExactExample.java
+++ b/master/src/test/java/com/examples/with/different/packagename/dse/invokedynamic/InvokeExactExample.java
@@ -1,0 +1,25 @@
+package com.examples.with.different.packagename.dse.invokedynamic;
+
+import java.io.PrintStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * Taken from Deep static analysis of invokeDynamic.
+ *
+ * @author Ignacio Lebrero
+ */
+public class InvokeExactExample {
+
+    public static void test1() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        MethodType mType = MethodType.methodType(void.class, String.class);
+        MethodHandle println = lookup.findVirtual(PrintStream.class, "println", mType);
+        println.invokeExact(System.out, "hello, world");
+
+        int pos = 0;  // receiver in leading position
+        MethodHandle println2out = MethodHandles.insertArguments(println, pos, System.out);
+        println2out.invokeExact("hello, world");
+    }
+}

--- a/master/src/test/java/org/evosuite/SystemTestBase.java
+++ b/master/src/test/java/org/evosuite/SystemTestBase.java
@@ -361,4 +361,10 @@ public class SystemTestBase {
 		assert (results.size() == 1);
 		return results.get(0).get(0).getDSEAlgorithm();
 	}
+
+	protected void checkDSEResultIsEmpty(Object result) {
+		assert (result instanceof List);
+		List<List<TestGenerationResult>> results = (List<List<TestGenerationResult>>) result;
+		assert (results.size() == 0);
+	}
 }

--- a/master/src/test/java/org/evosuite/dse/DSEAlgorithmSystemTest.java
+++ b/master/src/test/java/org/evosuite/dse/DSEAlgorithmSystemTest.java
@@ -25,6 +25,7 @@ import com.examples.with.different.packagename.dse.ByteExample;
 import com.examples.with.different.packagename.dse.CharExample;
 import com.examples.with.different.packagename.dse.DoubleExample;
 import com.examples.with.different.packagename.dse.FloatExample;
+import com.examples.with.different.packagename.dse.LocalClassExample;
 import com.examples.with.different.packagename.dse.LongExample;
 import com.examples.with.different.packagename.dse.Max;
 import com.examples.with.different.packagename.dse.Min;
@@ -634,5 +635,14 @@ public class DSEAlgorithmSystemTest extends DSESystemTestBase {
 
 		assertFalse(best.getTests().isEmpty());
 		assertTrue(best.getNumOfCoveredGoals() >= 3);
+	}
+
+	/**
+	 * So far, local classes goals are not being tracked by the static analysis stage of evosuite, so no tests are
+	 * outputted.
+	 */
+	@Test
+	public void testLocalClass() {
+		testDSEExecutionEmptyResult(LocalClassExample.class);
 	}
 }

--- a/master/src/test/java/org/evosuite/dse/DSEAlgorithmSystemTest.java
+++ b/master/src/test/java/org/evosuite/dse/DSEAlgorithmSystemTest.java
@@ -637,12 +637,8 @@ public class DSEAlgorithmSystemTest extends DSESystemTestBase {
 		assertTrue(best.getNumOfCoveredGoals() >= 3);
 	}
 
-	/**
-	 * So far, local classes goals are not being tracked by the static analysis stage of evosuite, so no tests are
-	 * outputted.
-	 */
 	@Test
 	public void testLocalClass() {
-		testDSEExecutionEmptyResult(LocalClassExample.class);
+		testDSEExecution(4, 1, LocalClassExample.class);
 	}
 }

--- a/master/src/test/java/org/evosuite/dse/DSEJDK9SystemTest.java
+++ b/master/src/test/java/org/evosuite/dse/DSEJDK9SystemTest.java
@@ -21,12 +21,15 @@ package org.evosuite.dse;
 
 import com.examples.with.different.packagename.dse.interfaces.InterfacePrivateMethodExample;
 import com.examples.with.different.packagename.dse.invokedynamic.ClosureFieldTest;
+import com.examples.with.different.packagename.dse.invokedynamic.InvokeExactExample;
 import com.examples.with.different.packagename.dse.invokedynamic.LambdaExample;
 import com.examples.with.different.packagename.dse.StreamAPIExample;
 import com.examples.with.different.packagename.dse.StringConcatenationExample;
 import com.examples.with.different.packagename.dse.invokedynamic.TestClosureClass;
 import com.examples.with.different.packagename.dse.invokedynamic.TestSAMConversions;
 import com.examples.with.different.packagename.dse.invokedynamic.SingleMethodReference;
+import org.evosuite.EvoSuite;
+import org.evosuite.Properties;
 import org.junit.Test;
 
 /**
@@ -69,6 +72,10 @@ public final class DSEJDK9SystemTest extends DSESystemTestBase {
 
 	/** Method Handles (JDK 8) */
 	// TODO: complete eventually, for now we won't support it as we don't support the reflection API either
+	@Test public void testInvokeExact() {
+		// As we don't support the Method handles API, there should be an exception throughout execution and the result should be empty.
+		testDSEExecutionEmptyResult(InvokeExactExample.class);
+	}
 
 	/**************** Milling Project Coin ****************/
 	@Test public void testPrivateMethodsInInterfaces() {

--- a/master/src/test/java/org/evosuite/dse/DSEJDK9SystemTest.java
+++ b/master/src/test/java/org/evosuite/dse/DSEJDK9SystemTest.java
@@ -46,7 +46,7 @@ public final class DSEJDK9SystemTest extends DSESystemTestBase {
 		testDSEExecution(8, 1, TestClosureClass.class);
 	}
 	@Test public void testClosureAsAField() {
-		testDSEExecution(8, 1, ClosureFieldTest.class);
+		testDSEExecution(2, 1, ClosureFieldTest.class);
 	}
 	@Test public void SAMConversion() {
 		testDSEExecution(3, 1, TestSAMConversions.class);
@@ -54,7 +54,7 @@ public final class DSEJDK9SystemTest extends DSESystemTestBase {
 
 	/** Method references (JDK 8) */
 	@Test public void testMethodReference() {
-		testDSEExecution(6, 2, SingleMethodReference.class);
+		testDSEExecution(7, 1, SingleMethodReference.class);
 	}
 
 	/** We are not currently supporting the Stream API as it calls lambdas from a non-instrumented context. */

--- a/master/src/test/java/org/evosuite/dse/DSEJDK9SystemTest.java
+++ b/master/src/test/java/org/evosuite/dse/DSEJDK9SystemTest.java
@@ -20,6 +20,7 @@
 package org.evosuite.dse;
 
 import com.examples.with.different.packagename.dse.interfaces.InterfacePrivateMethodExample;
+import com.examples.with.different.packagename.dse.invokedynamic.ClosureFieldTest;
 import com.examples.with.different.packagename.dse.invokedynamic.LambdaExample;
 import com.examples.with.different.packagename.dse.StreamAPIExample;
 import com.examples.with.different.packagename.dse.StringConcatenationExample;
@@ -43,6 +44,9 @@ public final class DSEJDK9SystemTest extends DSESystemTestBase {
 	}
 	@Test public void testClosure() {
 		testDSEExecution(8, 1, TestClosureClass.class);
+	}
+	@Test public void testClosureAsAField() {
+		testDSEExecution(8, 1, ClosureFieldTest.class);
 	}
 	@Test public void SAMConversion() {
 		testDSEExecution(3, 1, TestSAMConversions.class);

--- a/master/src/test/java/org/evosuite/dse/DSESystemTestBase.java
+++ b/master/src/test/java/org/evosuite/dse/DSESystemTestBase.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 public abstract class DSESystemTestBase extends SystemTestBase {
@@ -72,5 +73,26 @@ public abstract class DSESystemTestBase extends SystemTestBase {
 
 		assertEquals(expectedCoveredGoals, generatedTestSuite.getNumOfCoveredGoals());
 		assertEquals(expectedNotCoveredGoals, generatedTestSuite.getNumOfNotCoveredGoals());
+	}
+
+	/**
+	 * Runs DSE on a given SUT and checks for an expected amount of goals.
+	 *
+	 * @param SUT
+	 */
+	protected void testDSEExecutionEmptyResult(Class SUT) {
+		EvoSuite evosuite = new EvoSuite();
+		String targetClass = SUT.getCanonicalName();
+		Properties.TARGET_CLASS = targetClass;
+		Properties.SHOW_PROGRESS = true;
+
+		String[] command = new String[]{"-generateSuiteUsingDSE", "-class", targetClass};
+
+		Object result = evosuite.parseCommandLine(command);
+		ExplorationAlgorithmBase dse = getDSEAFromResult(result);
+		TestSuiteChromosome generatedTestSuite = dse.getGeneratedTestSuite();
+		System.out.println("Generated Test Suite:\n" + generatedTestSuite);
+
+		assertTrue(generatedTestSuite.getTests().isEmpty());
 	}
 }

--- a/master/src/test/java/org/evosuite/dse/DSESystemTestBase.java
+++ b/master/src/test/java/org/evosuite/dse/DSESystemTestBase.java
@@ -57,14 +57,7 @@ public abstract class DSESystemTestBase extends SystemTestBase {
 	 * @param SUT
 	 */
 	protected void testDSEExecution(int expectedCoveredGoals, int expectedNotCoveredGoals, Class SUT) {
-		EvoSuite evosuite = new EvoSuite();
-		String targetClass = SUT.getCanonicalName();
-		Properties.TARGET_CLASS = targetClass;
-		Properties.SHOW_PROGRESS = true;
-
-		String[] command = new String[]{"-generateSuiteUsingDSE", "-class", targetClass};
-
-		Object result = evosuite.parseCommandLine(command);
+		Object result = executeDSE(SUT);
 		ExplorationAlgorithmBase dse = getDSEAFromResult(result);
 		TestSuiteChromosome generatedTestSuite = dse.getGeneratedTestSuite();
 		System.out.println("Generated Test Suite:\n" + generatedTestSuite);
@@ -76,23 +69,27 @@ public abstract class DSESystemTestBase extends SystemTestBase {
 	}
 
 	/**
-	 * Runs DSE on a given SUT and checks for an expected amount of goals.
+	 * Runs DSE on a given SUT and checks that no result is returned
 	 *
 	 * @param SUT
 	 */
 	protected void testDSEExecutionEmptyResult(Class SUT) {
+		Object result = executeDSE(SUT);
+		checkDSEResultIsEmpty(result);
+	}
+
+	/**
+	 * Runs DSE on a given SUT.
+	 *
+	 * @param SUT
+	 */
+	private Object executeDSE(Class SUT) {
 		EvoSuite evosuite = new EvoSuite();
 		String targetClass = SUT.getCanonicalName();
 		Properties.TARGET_CLASS = targetClass;
 		Properties.SHOW_PROGRESS = true;
 
 		String[] command = new String[]{"-generateSuiteUsingDSE", "-class", targetClass};
-
-		Object result = evosuite.parseCommandLine(command);
-		ExplorationAlgorithmBase dse = getDSEAFromResult(result);
-		TestSuiteChromosome generatedTestSuite = dse.getGeneratedTestSuite();
-		System.out.println("Generated Test Suite:\n" + generatedTestSuite);
-
-		assertTrue(generatedTestSuite.getTests().isEmpty());
+		return evosuite.parseCommandLine(command);
 	}
 }


### PR DESCRIPTION
# Details

Ran benchmarks found in [1] (See [2] for it's artifacts) to validate the implementation of current invoke dynamic implementation.

# Fixed Bugs

## Local Classes
Local classes were [not being considered](https://github.com/ilebrero/evosuite/blob/java9Support_benchmarks/client/src/main/java/org/evosuite/symbolic/vm/CallVM.java#L1010) when checking if a method is instrumented before calling it. 

## Closures
Fixed closures that were not executed right away losing track of their bounded elements. At a byte code level, bounded variables are transformed into parameters for the resulting synthetic method while, on the other hand, the closure anonymous callable object created by invokedynamic keeps the original descriptor. To fix it, track of the bounded variables is added, this are later pushed to the operand stack before calling the closure's callable object.

# Notes
[Method Handles API](https://docs.oracle.com/javase/9/docs/api/java/lang/invoke/MethodHandles.html) is not supported yet. Benchmarks on these will fail to run.

# Sources
Benchmark jars, source files and running scripts can be found in this [zip file](https://drive.google.com/file/d/1sP-_6dd9Ircsowkd5HQaITskjaFzRQOK/view?usp=sharing).

# References
1. Fourtounis, George, y Yannis Smaragdakis. «Deep Static Modeling of invokedynamic». En 33rd European Conference on Object-Oriented Programming (ECOOP 2019), editado por Alastair F. Donaldson, 134:15:1–15:28. Leibniz International Proceedings in Informatics (LIPIcs). Dagstuhl, Germany: Schloss Dagstuhl–Leibniz-Zentrum fuer Informatik, 2019. https://doi.org/10.4230/LIPIcs.ECOOP.2019.15.
2. George Fourtounis, y Yannis Smaragdakis. Deep Static Modeling of invokedynamic (artifact). Zenodo, 2020. https://doi.org/10.5281/zenodo.3855435.